### PR TITLE
Catch NullPointerException occurring in stopFlushTimer

### DIFF
--- a/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/parselyandroid/ParselyTracker.java
@@ -282,7 +282,11 @@ public class ParselyTracker {
     public void stopFlushTimer(){
         if(this.timer != null){
             this.timer.cancel();
-            this.timer.purge();
+            try {
+                this.timer.purge();
+            } catch (NullPointerException ex) {
+                PLog("Exception caught during Timer.purge(): %s", ex.toString());
+            }
         }
         this.timer = null;
     }


### PR DESCRIPTION
My reading of the android traceback in [this ticket](https://github.com/Parsely/web/issues/7005#issuecomment-344055353) is that there's a `NullPointerException` bubbling out of `ParselyTracker.stopTimerFlush`. I couldn't recreate it. The customer didn't really give me any information other than it's happening most often on Samsung devices and in Android 7. I looked at all the events in datadog from August 10th when the customer reported the problem starting, nothing stood out. I investigated the java.util.Timer class. It looks to me like calling `purge` after calling `cancel` and then setting `this.timer` to `null` is duplicative. Both setting timer to `null` and calling `purge` dereference the queue, timer, and it's tasks so that GC will collect them.  I did find alternative opinions saying that you should call `purge` after `cancel`. So this seemed like the optimal solution. Purge where you can, if it fails catch the exception, log, set `this.timer` to `null`, and move on. 