### PR TITLE
Initialize stored queue rather than setting it to null

### DIFF
--- a/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/parselyandroid/ParselyTracker.java
@@ -534,7 +534,7 @@ public class ParselyTracker {
      *
      */
     protected void purgeStoredQueue() {
-        this.persistObject(null);
+        this.persistObject(new ArrayList<Map<String, Object>>());
     }
 
     /*! \brief Delete an event from the stored queue.


### PR DESCRIPTION
This initializes the stored queue as an empty ArrayList rather than nulling it.

Tested in the example app and no errors were visible.

Fixes https://github.com/Parsely/parsely-android/issues/26