### PR TITLE
fix: bump Jackson to 2.13.3

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -12,11 +12,6 @@ android {
         versionCode 1
         versionName "1.0"
     }
-    packagingOptions {
-        exclude 'META-INF/LGPL2.1'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/NOTICE'
-    }
 }
 
 dependencies {

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -32,7 +32,7 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'org.codehaus.jackson:jackson-mapper-lgpl:1.9.13'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     implementation 'com.google.android.gms:play-services-ads:21.0.0'
 }
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -27,11 +27,10 @@ import android.provider.Settings.Secure;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.android.gms.ads.identifier.AdvertisingIdClient;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
-
-import org.codehaus.jackson.map.ObjectMapper;
 
 import java.io.EOFException;
 import java.io.FileInputStream;


### PR DESCRIPTION
Closes: #45 

### Description

This PR updates Jackson (JSON parser) library. The update is forced because of a security flaw of the currently used version ([details](https://ossindex.sonatype.org/vulnerability/CVE-2017-7525?component-type=maven&component-name=org.codehaus.jackson%2Fjackson-mapper-lgpl&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0)).

### How I tested the change

I've taken parsed data after pressing all buttons from top to bottom in the example app, before and after the version bump. See `ParselyTracker#JsonEncode` method.

The diff result is the following:
https://www.diffchecker.com/vtzFPlw2

If I interpret the result correctly the changes are related to:
- timestamp ✅
- order of the parsed objects. But `java.util.HashMap` is already a map that does not respect the order of the values so the dependency bump did not change this behavior. ✅

Taking both into account I think that the bump is safe.