### PR TITLE
Set `minSdk` to 21, `compile` and `target` to 33

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.parsely.example.parselyexample"
-        minSdkVersion 23
-        targetSdkVersion 32
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
     }

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.library'
 }
 
-ext.VERSION = '3.0.3'
+ext.VERSION = '3.0.4'
 
 android {
     compileSdkVersion 33

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -5,11 +5,11 @@ plugins {
 ext.VERSION = '3.0.3'
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     defaultConfig {
-        minSdkVersion 23
-        targetSdkVersion 32
+        minSdkVersion 21
+        targetSdkVersion 33
     }
     buildTypes {
         release {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 pluginManagement {
-    gradle.ext.agpVersion = '7.2.1'
+    gradle.ext.agpVersion = '7.2.2'
 
     plugins {
         id 'com.android.application' version gradle.ext.agpVersion


### PR DESCRIPTION
### Description

This PR is answering the customer request of setting `minSdk` to 21 and `targetSdk` to the currently newest. See internal communication: pd3OIC-mg-p2#comment-153.

### Testing

I don't see an appropriate suggestion for testing. I've run the `example` app, and it also seems to work fine on API 21. 

