### PR TITLE
fix: Remove Google Mobile Ads SDK

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -14,9 +14,6 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
-        <meta-data
-            android:name="com.google.android.gms.ads.APPLICATION_ID"
-            android:value="ca-app-pub-3940256099942544~3347511713"/>
         <activity
             android:name=".MainActivity"
             android:theme="@style/AppTheme.NoActionBar"

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -33,7 +33,7 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
-    implementation 'com.google.android.gms:play-services-ads:21.0.0'
+    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
 }
 
 apply from: "${rootProject.projectDir}/publication.gradle"


### PR DESCRIPTION
## Problem
The library includes the full [Google Mobile Ads SDK](https://developers.google.com/admob/android/quick-start) in order to access the Android Advertising ID (AAID). This causes a crash when including Parse.ly as the Ads library expects to be initialised with an AdMob app ID.

### Example crash log

```
java.lang.RuntimeException: Unable to get provider com.google.android.gms.ads.MobileAdsInitProvider: java.lang.IllegalStateException: 
    
    ******************************************************************************
    * The Google Mobile Ads SDK was initialized incorrectly. AdMob publishers    *
    * should follow the instructions here:                                       *
    * https://googlemobileadssdk.page.link/admob-android-update-manifest         *
    * to add a valid App ID inside the AndroidManifest.                          *
    * Google Ad Manager publishers should follow instructions here:              *
    * https://googlemobileadssdk.page.link/ad-manager-android-update-manifest.   *
    ******************************************************************************
```

## Solution
Replace the full Google Mobile Ads SDK with the [Advertising ID](https://developers.google.com/android/reference/com/google/android/gms/ads/identifier/AdvertisingIdClient) library which includes only what's needed by the Parse.ly code.