### PR TITLE
fix: initialize deviceInfo before putting adKey there

### DIFF
--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -87,7 +87,6 @@ public class ParselyTracker {
         this.rootUrl = "https://p1.parsely.com/";
         this.queueSizeLimit = 50;
         this.storageSizeLimit = 100;
-        this.deviceInfo = this.collectDeviceInfo();
         this.timer = new Timer();
         this.isDebug = false;
 
@@ -757,6 +756,7 @@ public class ParselyTracker {
         @Override
         protected void onPostExecute(String advertId) {
             adKey = advertId;
+            deviceInfo = collectDeviceInfo();
             deviceInfo.put("parsely_site_uuid", adKey);
         }
 


### PR DESCRIPTION
This PR tries to address NPE crash that happens in `GetAdKey#onPostExecute`.

Unfortunately, I wasn't able to reproduce the issue, though I think that provided change will address the problem.

#### How NPE happens

In the constructor of `ParselyTracker` we, launch `GetAdKey` AsyncTask which, in its `onPostExecute`, adds `adKey` to `deviceInfo` Map.

But the `deviceInfo` Map is created **after** `GetAdKey` is executed. This makes it possible that `deviceInfo` won't be created before `GetAdKey` tries to use it - hence the NPE.

I wasn't able to reproduce the issue because `GetAdKey#onPostExecute` happens on the main thread, so we have race condition on the main thread, so it's impossible to modify flow via `Thread#sleep`.

#### How to test

As we don't have reproduction, please focus on the code - does the proposed change have some side effects? Did I miss something, will it break any other feature?