### PR TITLE
Initialize `deviceInfo` in constructor of `ParselyTracker`

### DIFF
--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -60,7 +60,7 @@ public class ParselyTracker {
     private static int DEFAULT_FLUSH_INTERVAL_SECS = 60;
     private static int DEFAULT_ENGAGEMENT_INTERVAL_MILLIS = 10500;
     protected ArrayList<Map<String, Object>> eventQueue;
-    private String siteId, rootUrl, storageKey, uuidKey, adKey;
+    private String siteId, rootUrl, storageKey, uuidKey;
     private boolean isDebug;
     private SharedPreferences settings;
     private int queueSizeLimit, storageSizeLimit;
@@ -79,7 +79,6 @@ public class ParselyTracker {
 
         this.siteId = siteId;
         this.uuidKey = "parsely-uuid";
-        this.adKey = null;
         // get the adkey straight away on instantiation
         new GetAdKey(c).execute();
         this.storageKey = "parsely-events.ser";
@@ -638,12 +637,12 @@ public class ParselyTracker {
      *
      * Collects info about the device and user to use in Parsely events.
      */
-    private Map<String, String> collectDeviceInfo() {
+    private Map<String, String> collectDeviceInfo(@Nullable final String adKey) {
         Map<String, String> dInfo = new HashMap<>();
 
         // TODO: screen dimensions (maybe?)
-        PLog("adkey is: %s, uuid is %s", this.adKey, this.getSiteUuid());
-        String uuid = (this.adKey != null) ? this.adKey : this.getSiteUuid();
+        PLog("adkey is: %s, uuid is %s", adKey, this.getSiteUuid());
+        final String uuid = (adKey != null) ? adKey : this.getSiteUuid();
         dInfo.put("parsely_site_uuid", uuid);
         dInfo.put("manufacturer", android.os.Build.MANUFACTURER);
         dInfo.put("os", "android");
@@ -755,9 +754,7 @@ public class ParselyTracker {
 
         @Override
         protected void onPostExecute(String advertId) {
-            adKey = advertId;
-            deviceInfo = collectDeviceInfo();
-            deviceInfo.put("parsely_site_uuid", adKey);
+            deviceInfo = collectDeviceInfo(advertId);
         }
 
     }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -80,6 +80,7 @@ public class ParselyTracker {
         this.siteId = siteId;
         this.uuidKey = "parsely-uuid";
         // get the adkey straight away on instantiation
+        this.deviceInfo = collectDeviceInfo(null);
         new GetAdKey(c).execute();
         this.storageKey = "parsely-events.ser";
         //this.rootUrl = "http://10.0.2.2:5001/";  // emulator localhost


### PR DESCRIPTION
Closes: #57 

## Description

This PR addresses the issue reported in #57 by initializing `deviceInfo` synchronously in the constructor of the `ParselyTracker`, rather than waiting for `GetAdKey` async task to complete.

It brings back part of the behavior from before #56 (which introduced the discussed bug) but makes it more explicitly, that initial creation of `deviceInfo` passes `null` for `adKey` property.

## Reproduction

1. Checkout `trunk`
2. Apply the PATCH

<details>
<summary>PATCH</summary>

```PATCH
Subject: [PATCH] refactor: move plugins configuration to pluginManagement
---
Index: parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java	(revision 652ccbec41975239f3981289d94a40335f2495b2)
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java	(date 1693839376735)
@@ -738,6 +738,11 @@
         protected String doInBackground(Void... params) {
             AdvertisingIdClient.Info idInfo = null;
             String advertId = null;
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
             try {
                 idInfo = AdvertisingIdClient.getAdvertisingIdInfo(mContext);
             } catch (GooglePlayServicesRepairableException | IOException | GooglePlayServicesNotAvailableException | IllegalArgumentException e) {
``` 

</details>

3. Run the `example` app and within 10 seconds tap on "track url" button.