### PR TITLE
Copy `data` map when creating a new heartbeat event

### DIFF
--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -894,11 +894,10 @@ public class ParselyTracker {
             Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
             @SuppressWarnings("unchecked")
             Map<String, Object> baseEventData = (Map<String, Object>) event.get("data");
-            if (baseEventData != null) {
-                Map<String, Object> data = new HashMap<>((Map<String, Object>) baseEventData);
-                data.put("ts", now.getTimeInMillis() / 1000);
-                event.put("data", data);
-            }
+            assert baseEventData != null;
+            Map<String, Object> data = new HashMap<>((Map<String, Object>) baseEventData);
+            data.put("ts", now.getTimeInMillis() / 1000);
+            event.put("data", data);
 
             // Adjust inc by execution time in case we're late or early.
             long executionDiff = (System.currentTimeMillis() - scheduledExecutionTime);

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -887,7 +887,7 @@ public class ParselyTracker {
 
         private void doEnqueue(long scheduledExecutionTime) {
             // Create a copy of the base event to enqueue
-            Map<String, Object> event = new HashMap(this.baseEvent);
+            Map<String, Object> event = new HashMap<>(this.baseEvent);
             PLog(String.format("Enqueuing %s event.", event.get("action")));
 
             // Update `ts` for the event since it's happening right now.

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -892,6 +892,7 @@ public class ParselyTracker {
 
             // Update `ts` for the event since it's happening right now.
             Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+            @SuppressWarnings("unchecked")
             Map<String, Object> baseEventData = (Map<String, Object>) event.get("data");
             if (baseEventData != null) {
                 Map<String, Object> data = new HashMap<>((Map<String, Object>) baseEventData);

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -892,9 +892,12 @@ public class ParselyTracker {
 
             // Update `ts` for the event since it's happening right now.
             Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-            Map<String, Object> data = new HashMap<>((Map<String, Object>) event.get("data"));
-            data.put("ts", now.getTimeInMillis() / 1000);
-            event.put("data", data);
+            Map<String, Object> baseEventData = (Map<String, Object>) event.get("data");
+            if (baseEventData != null) {
+                Map<String, Object> data = new HashMap<>((Map<String, Object>) baseEventData);
+                data.put("ts", now.getTimeInMillis() / 1000);
+                event.put("data", data);
+            }
 
             // Adjust inc by execution time in case we're late or early.
             long executionDiff = (System.currentTimeMillis() - scheduledExecutionTime);

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -892,8 +892,9 @@ public class ParselyTracker {
 
             // Update `ts` for the event since it's happening right now.
             Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-            Map<String, Object> data = (Map<String, Object>) event.get("data");
+            Map<String, Object> data = new HashMap<>((Map<String, Object>) event.get("data"));
             data.put("ts", now.getTimeInMillis() / 1000);
+            event.put("data", data);
 
             // Adjust inc by execution time in case we're late or early.
             long executionDiff = (System.currentTimeMillis() - scheduledExecutionTime);


### PR DESCRIPTION
Closes: #60 

Instead of referencing to the same `Map<String, Object> data` across all events, when updating timestamps of events in `EngagementManager`, we will now create a shallow copy of `data`. This way will stop introducing unwanted changes of data.ts to existing events.

### Screen from debugger

You can see that after the change, each event has its own `data` HashMap so they can update it independently.

| Before | After |
| --- | --- | 
| <img width="492" alt="Screenshot 2023-09-07 at 14 49 44" src="https://github.com/Parsely/parsely-android/assets/5845095/f510125c-0a0a-4d99-92af-a41f7dbd851d"> | <img width="385" alt="Screenshot 2023-09-07 at 14 50 50" src="https://github.com/Parsely/parsely-android/assets/5845095/aae989c6-acd4-45c9-8e6f-fb640cfa06fa"> |

### Payload result

You can see that each event has now its own timestamp of record

| Before | After | 
| --- | --- | 
| <img width="663" alt="Screenshot 2023-09-07 at 11 47 11" src="https://github.com/Parsely/parsely-android/assets/5845095/b8aba3cf-bcaa-475e-88aa-c6284a03abdf"> | <img width="660" alt="Screenshot 2023-09-07 at 11 50 06" src="https://github.com/Parsely/parsely-android/assets/5845095/d947ee6e-3736-416f-a8e2-774d0e5e5a78"> |
