### PR TITLE
Use milliseconds for `ts` and `tt` parameters

### DIFF
--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -404,7 +404,7 @@ public class ParselyTracker {
         data.put("manufacturer", this.deviceInfo.get("manufacturer"));
         data.put("os", this.deviceInfo.get("os"));
         data.put("os_version", this.deviceInfo.get("os_version"));
-        data.put("ts", now.getTimeInMillis() / 1000);
+        data.put("ts", now.getTimeInMillis());
         data.put("parsely_site_uuid", this.deviceInfo.get("parsely_site_uuid"));
         event.put("data", data);
 
@@ -893,7 +893,7 @@ public class ParselyTracker {
             // Update `ts` for the event since it's happening right now.
             Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
             Map<String, Object> data = (Map<String, Object>) event.get("data");
-            data.put("ts", now.getTimeInMillis() / 1000);
+            data.put("ts", now.getTimeInMillis());
 
             // Adjust inc by execution time in case we're late or early.
             long executionDiff = (System.currentTimeMillis() - scheduledExecutionTime);

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -897,9 +897,9 @@ public class ParselyTracker {
 
             // Adjust inc by execution time in case we're late or early.
             long executionDiff = (System.currentTimeMillis() - scheduledExecutionTime);
-            long inc = (this.latestDelayMillis + executionDiff) / 1000;
+            long inc = (this.latestDelayMillis + executionDiff);
             this.totalTime += inc;
-            event.put("inc", inc);
+            event.put("inc", inc / 1000);
             event.put("tt", this.totalTime);
 
             enqueueEvent(event);


### PR DESCRIPTION
### Description

Closes: #61 

This PR updates time units for `tt` (total time) and `data.ts` (timestamp) parameters. This will match iOS behaviour and was discussed internally here: pd3OIC-1is-p2#comment-313


| Before | After |
| --- | --- | 
| <img width="569" alt="Screenshot 2023-09-07 at 15 50 18" src="https://github.com/Parsely/parsely-android/assets/5845095/c64824d0-d286-486d-9a0e-00f02193150c"> | <img width="572" alt="Screenshot 2023-09-07 at 15 48 21" src="https://github.com/Parsely/parsely-android/assets/5845095/d6e08411-983d-4668-a7b9-713b8ae0f3c6"> |


