### PR TITLE
docs: update README and minor MavenCentral pom file attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Parsely Android SDK
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.parsely/parsely.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22com.parsely%22%20AND%20a:%22parsely%22) [![Assemble project](https://github.com/Parsely/parsely-android/actions/workflows/readme.yml/badge.svg)](https://github.com/Parsely/parsely-android/actions/workflows/readme.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/com.parsely/parsely.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.parsely/parsely) [![Assemble project](https://github.com/Parsely/parsely-android/actions/workflows/readme.yml/badge.svg)](https://github.com/Parsely/parsely-android/actions/workflows/readme.yml)
 
 The Parse.ly Android SDK is a Java library providing Parse.ly tracking functionality to native
 Android apps. Like any other framework you might include in your project, the Parse.ly SDK provides
@@ -17,4 +17,4 @@ implementation("com.parsely:parsely:<release_version>")
 ## Using the SDK
 
 Full instructions and documentation can be found on
-the [Parse.ly help page](https://www.parse.ly/help/integration/android-sdk/).
+the [Parse.ly help page](https://docs.parse.ly/android-sdk/).

--- a/publication.gradle
+++ b/publication.gradle
@@ -45,13 +45,10 @@ publishing {
                         developerConnection = 'scm:git:ssh://github.com/Parsely/parsely-android.git'
                         url = 'https://github.com/Parsely/parsely-android/tree/main'
                     }
-
-                    developers {
-                        developer {
-                            id = 'emmettbutler'
-                            name = 'Emmett Butler'
-                            email = 'emmett.butler@automattic.com'
-                        }
+                
+                    organization {
+                        name = 'Parse.ly'
+                        url = 'https://www.parse.ly/'
                     }
                 }
             }


### PR DESCRIPTION
### Description 

This small PR updates documentation link for the Android SDK and removes `developers` attribute in favor of `organiation` (less prone to changes).