### PR TITLE
feat: allow to add extradata in engagement session

### DIFF
--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -2,6 +2,8 @@ package com.example;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -116,7 +118,9 @@ public class MainActivity extends Activity {
     }
 
     public void startEngagement(View view) {
-        ParselyTracker.sharedInstance().startEngagement("http://example.com/article1.html", "http://example.com/");
+        final Map<String, Object> extraData = new HashMap<>();
+        extraData.put("product-id", "12345");
+        ParselyTracker.sharedInstance().startEngagement("http://example.com/article1.html", "http://example.com/", extraData);
         updateEngagementStrings();
     }
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -243,6 +243,21 @@ public class ParselyTracker {
      * @param urlRef Referrer URL associated with this video view.
      */
     public void startEngagement(@NonNull String url, @Nullable String urlRef) {
+        startEngagement(url, urlRef, null);
+    }
+
+    /**
+     * Same as {@link #startEngagement(String, String)} but with extra data.
+     *
+     * @param url       The URL to track engaged time for.
+     * @param urlRef    Referrer URL associated with this video view.
+     * @param extraData A Map of additional information to send with the event.
+     */
+    public void startEngagement(
+            final @NonNull String url,
+            @Nullable String urlRef,
+            final @Nullable Map<String, Object> extraData
+    ) {
         if (url.equals("")) {
             throw new IllegalArgumentException("url cannot be null or empty.");
         }
@@ -255,7 +270,7 @@ public class ParselyTracker {
         stopEngagement();
 
         // Start a new EngagementTask
-        Map<String, Object> event = buildEvent(url, urlRef, "heartbeat", null, null);
+        Map<String, Object> event = buildEvent(url, urlRef, "heartbeat", null, extraData);
         engagementManager = new EngagementManager(timer, DEFAULT_ENGAGEMENT_INTERVAL_MILLIS, event);
         engagementManager.start();
     }


### PR DESCRIPTION
Closes: #33 
Closes: #69 

### Description
This PR allows users to specify `extraData` for engagement sessions. As rightfully noticed by users in tickets, this feature is already documented and in iOS SDK.

| Android | iOS |
| --- | --- | 
| <img width="603" alt="Screenshot 2023-09-14 at 17 57 27" src="https://github.com/Parsely/parsely-android/assets/5845095/aa93ec2e-4a0f-4970-9172-65b228338f6b"> | <img width="568" alt="Screenshot 2023-09-14 at 17 33 49" src="https://github.com/Parsely/parsely-android/assets/5845095/b1f2745d-32ef-4e7b-8f59-f2a3fb5c4882"> |

