### PR TITLE
docs: ParselyTracker comments to Javadoc style

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -28,3 +28,8 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      - name: Publish build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifact
+          path: ~/.m2/repository/com/parsely/parsely/*

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 # Default value: -Xmx10248m -XX:MaxPermSize=256m
 # org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -26,6 +26,7 @@ android {
     publishing {
         singleVariant('release') {
             withSourcesJar()
+            withJavadocJar()
         }
     }
 }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyMetadata.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyMetadata.java
@@ -7,27 +7,29 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
-/*! \brief Represents post metadata to be passed to Parsely tracking.
- *
- *  This class is used to attach a metadata block to a Parse.ly pageview
- *  request. Pageview metadata is only required for URLs not accessible over the
- *  internet (i.e. app-only content) or if the customer is using an "in-pixel" integration.
- *  Otherwise, metadata will be gathered by Parse.ly's crawling infrastructure.
+/**
+ * Represents post metadata to be passed to Parsely tracking.
+ * <p>
+ * This class is used to attach a metadata block to a Parse.ly pageview
+ * request. Pageview metadata is only required for URLs not accessible over the
+ * internet (i.e. app-only content) or if the customer is using an "in-pixel" integration.
+ * Otherwise, metadata will be gathered by Parse.ly's crawling infrastructure.
  */
 public class ParselyMetadata {
     public ArrayList<String> authors, tags;
     public String link, section, thumbUrl, title;
     public Calendar pubDate;
 
-    /* \brief Create a new ParselyMetadata object.
+    /**
+     * Create a new ParselyMetadata object.
      *
-     * @param authors         The names of the authors of the content. Up to 10 authors are accepted.
-     * @param link            A post's canonical url.
-     * @param section         The category or vertical to which this content belongs.
-     * @param tags            User-defined tags for the content. Up to 20 are allowed.
-     * @param thumbUrl        URL at which the main image for this content is located.
-     * @param title           The title of the content.
-     * @param pubDate         The date this piece of content was published.
+     * @param authors  The names of the authors of the content. Up to 10 authors are accepted.
+     * @param link     A post's canonical url.
+     * @param section  The category or vertical to which this content belongs.
+     * @param tags     User-defined tags for the content. Up to 20 are allowed.
+     * @param thumbUrl URL at which the main image for this content is located.
+     * @param title    The title of the content.
+     * @param pubDate  The date this piece of content was published.
      */
     public ParselyMetadata(
             @Nullable ArrayList<String> authors,
@@ -47,7 +49,8 @@ public class ParselyMetadata {
         this.pubDate = pubDate;
     }
 
-    /* \brief Turn this object into a Map
+    /**
+     * Turn this object into a Map
      *
      * @return a Map object representing the metadata.
      */

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -48,10 +48,11 @@ import java.util.TimeZone;
 import java.util.Timer;
 import java.util.TimerTask;
 
-/*! \brief Tracks Parse.ly app views in Android apps
- *
- *  Accessed as a singleton. Maintains a queue of pageview events in memory and periodically
- *  flushes the queue to the Parse.ly pixel proxy server.
+/**
+ * Tracks Parse.ly app views in Android apps
+ * <p>
+ * Accessed as a singleton. Maintains a queue of pageview events in memory and periodically
+ * flushes the queue to the Parse.ly pixel proxy server.
  */
 public class ParselyTracker {
     private static ParselyTracker instance = null;
@@ -75,8 +76,8 @@ public class ParselyTracker {
     private final FlushManager flushManager;
     private EngagementManager engagementManager, videoEngagementManager;
 
-    /*! \brief Create a new ParselyTracker instance.
-     *
+    /**
+     * Create a new ParselyTracker instance.
      */
     protected ParselyTracker(String siteId, int flushInterval, Context c) {
         context = c.getApplicationContext();
@@ -98,11 +99,11 @@ public class ParselyTracker {
         }
     }
 
-    /*! \brief Singleton instance accessor. Note: This must be called after
-    sharedInstance(String, Context)
-    *
-    *  @return The singleton instance
-    */
+    /**
+     * Singleton instance accessor. Note: This must be called after {@link #sharedInstance(String, Context)}
+     *
+     * @return The singleton instance
+     */
     public static ParselyTracker sharedInstance() {
         if (instance == null) {
             return null;
@@ -110,22 +111,24 @@ public class ParselyTracker {
         return instance;
     }
 
-    /*! \brief Singleton instance factory Note: this must be called before `sharedInstance()`
+    /**
+     * Singleton instance factory Note: this must be called before {@link #sharedInstance()}
      *
-     *  @param siteId The Parsely public site id (eg "example.com")
-     *  @param c      The current Android application context
-     *  @return       The singleton instance
+     * @param siteId The Parsely public site id (eg "example.com")
+     * @param c      The current Android application context
+     * @return The singleton instance
      */
     public static ParselyTracker sharedInstance(String siteId, Context c) {
         return ParselyTracker.sharedInstance(siteId, DEFAULT_FLUSH_INTERVAL_SECS, c);
     }
 
-    /*! \brief Singleton instance factory Note: this must be called before `sharedInstance()`
+    /**
+     * Singleton instance factory Note: this must be called before {@link #sharedInstance()}
      *
-     *  @param siteId        The Parsely public site id (eg "example.com")
-     *  @param flushInterval The interval at which the events queue should flush, in seconds
-     *  @param c             The current Android application context
-     *  @return              The singleton instance
+     * @param siteId        The Parsely public site id (eg "example.com")
+     * @param flushInterval The interval at which the events queue should flush, in seconds
+     * @param c             The current Android application context
+     * @return The singleton instance
      */
     public static ParselyTracker sharedInstance(String siteId, int flushInterval, Context c) {
         if (instance == null) {
@@ -134,8 +137,8 @@ public class ParselyTracker {
         return instance;
     }
 
-    /*! \brief Log a message to the console.
-     *
+    /**
+     * Log a message to the console.
      */
     protected static void PLog(String logString, Object... objects) {
         if (logString.equals("")) {
@@ -144,7 +147,8 @@ public class ParselyTracker {
         System.out.println(new Formatter().format("[Parsely] " + logString, objects).toString());
     }
 
-    /*! \brief Get the heartbeat interval
+    /**
+     * Get the heartbeat interval
      *
      * @return The base engagement tracking interval.
      */
@@ -162,7 +166,8 @@ public class ParselyTracker {
         return videoEngagementManager.getIntervalMillis();
     }
 
-    /*! \brief Returns whether the engagement tracker is running.
+    /**
+     * Returns whether the engagement tracker is running.
      *
      * @return Whether the engagement tracker is running.
      */
@@ -170,7 +175,8 @@ public class ParselyTracker {
         return engagementManager != null && engagementManager.started;
     }
 
-    /*! \brief Returns whether video tracking is active.
+    /**
+     * Returns whether video tracking is active.
      *
      * @return Whether video tracking is active.
      */
@@ -178,7 +184,8 @@ public class ParselyTracker {
         return videoEngagementManager != null && videoEngagementManager.started;
     }
 
-    /*! \brief Returns the interval at which the event queue is flushed to Parse.ly.
+    /**
+     * Returns the interval at which the event queue is flushed to Parse.ly.
      *
      * @return The interval at which the event queue is flushed to Parse.ly.
      */
@@ -186,7 +193,8 @@ public class ParselyTracker {
         return flushManager.getIntervalMillis() / 1000;
     }
 
-    /*! \brief Getter for isDebug
+    /**
+     * Getter for isDebug
      *
      * @return Whether debug mode is active.
      */
@@ -194,19 +202,21 @@ public class ParselyTracker {
         return isDebug;
     }
 
-    /*! \brief Set a debug flag which will prevent data from being sent to Parse.ly
+    /**
+     * Set a debug flag which will prevent data from being sent to Parse.ly
+     * <p>
+     * Use this flag when developing to prevent the SDK from actually sending requests
+     * to Parse.ly servers. The value it would otherwise send is logged to the console.
      *
-     *  Use this flag when developing to prevent the SDK from actually sending requests
-     *  to Parse.ly servers. The value it would otherwise send is logged to the console.
-     *
-     *  @param debug Value to use for debug flag.
+     * @param debug Value to use for debug flag.
      */
     public void setDebug(boolean debug) {
         isDebug = debug;
         PLog("Debugging is now set to " + isDebug);
     }
 
-    /*! \brief Register a pageview event using a URL and optional metadata.
+    /**
+     * Register a pageview event using a URL and optional metadata.
      *
      * @param url         The URL of the article being tracked
      *                    (eg: "http://example.com/some-old/article.html")
@@ -233,8 +243,9 @@ public class ParselyTracker {
         enqueueEvent(buildEvent(url, urlRef, "pageview", urlMetadata, extraData));
     }
 
-    /*! \brief Start engaged time tracking for the given URL.
-     *
+    /**
+     * Start engaged time tracking for the given URL.
+     * <p>
      * This starts a timer which will send events to Parse.ly on a regular basis
      * to capture engaged time for this URL. The value of `url` should be a URL for
      * which `trackPageview` has been called.
@@ -275,8 +286,9 @@ public class ParselyTracker {
         engagementManager.start();
     }
 
-    /*! \brief Stop engaged time tracking.
-     *
+    /**
+     * Stop engaged time tracking.
+     * <p>
      * Stops the engaged time tracker, sending any accumulated engaged time to Parse.ly.
      * NOTE: This **must** be called in your `MainActivity` during various Android lifecycle events
      * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
@@ -290,12 +302,13 @@ public class ParselyTracker {
         engagementManager = null;
     }
 
-    /*! \brief Start video tracking.
-     *
+    /**
+     * Start video tracking.
+     * <p>
      * Starts tracking view time for a video being viewed at a given url. Will send a `videostart`
      * event unless the same url/videoId had previously been paused.
      * Video metadata must be provided, specifically the video ID and video duration.
-     *
+     * <p>
      * The `url` value is *not* the URL of a video, but the post which contains the video. If the video
      * is not embedded in a post, then this should contain a well-formatted URL on the customer's
      * domain (e.g. http://<CUSTOMERDOMAIN>/app-videos). This URL doesn't need to return a 200 status
@@ -347,13 +360,14 @@ public class ParselyTracker {
         videoEngagementManager.start();
     }
 
-    /*! \brief Pause video tracking.
-     *
-     * Pauses video tracking for an ongoing video. If `trackPlay` is immediately called again for
+    /**
+     * Pause video tracking.
+     * <p>
+     * Pauses video tracking for an ongoing video. If {@link #trackPlay} is immediately called again for
      * the same video, a new video start event will not be sent. This models a user pausing a
      * playing video.
-     *
-     * NOTE: This or `resetVideo` **must** be called in your `MainActivity` during various Android lifecycle events
+     * <p>
+     * NOTE: This or {@link #resetVideo} **must** be called in your `MainActivity` during various Android lifecycle events
      * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
      * and Parse.ly values may be inaccurate.
      */
@@ -364,13 +378,14 @@ public class ParselyTracker {
         videoEngagementManager.stop();
     }
 
-    /*! \brief Reset tracking on a video.
-     *
-     * Stops video tracking and resets internal state for the video. If `trackPlay` is immediately
+    /**
+     * Reset tracking on a video.
+     * <p>
+     * Stops video tracking and resets internal state for the video. If {@link #trackPlay} is immediately
      * called for the same video, a new video start event is set. This models a user stopping a
-     * video and (on `trackPlay` being called again) starting it over.
-     *
-     * NOTE: This or `trackPause` **must** be called in your `MainActivity` during various Android lifecycle events
+     * video and (on {@link #trackPlay} being called again) starting it over.
+     * <p>
+     * NOTE: This or {@link #trackPause} **must** be called in your `MainActivity` during various Android lifecycle events
      * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
      * and Parse.ly values may be inaccurate.
      */
@@ -382,13 +397,14 @@ public class ParselyTracker {
         videoEngagementManager = null;
     }
 
-    /*! \brief Create an event Map
+    /**
+     * Create an event Map
      *
-     *  @param url       The URL identifying the pageview/heartbeat
-     *  @param action    Action to use (e.g. pageview, heartbeat, videostart, vheartbeat)
-     *  @param metadata  Metadata to attach to the event.
-     *  @param extraData A Map of additional information to send with the event.
-     *  @return          A Map object representing the event to be sent to Parse.ly.
+     * @param url       The URL identifying the pageview/heartbeat
+     * @param action    Action to use (e.g. pageview, heartbeat, videostart, vheartbeat)
+     * @param metadata  Metadata to attach to the event.
+     * @param extraData A Map of additional information to send with the event.
+     * @return A Map object representing the event to be sent to Parse.ly.
      */
     private Map<String, Object> buildEvent(
             String url,
@@ -426,14 +442,15 @@ public class ParselyTracker {
         return event;
     }
 
-    /*! \brief Add an event Map to the queue.
+    /**
+     * Add an event Map to the queue.
+     * <p>
+     * Place a data structure representing the event into the in-memory queue for later use.
+     * <p>
+     * **Note**: Events placed into this queue will be discarded if the size of the persistent queue
+     * store exceeds {@link #STORAGE_SIZE_LIMIT}.
      *
-     *  Place a data structure representing the event into the in-memory queue for later use.
-     *
-     *  **Note**: Events placed into this queue will be discarded if the size of the persistent queue
-     *  store exceeds `STORAGE_SIZE_LIMIT`.
-     *
-     *  @param event The event Map to enqueue.
+     * @param event The event Map to enqueue.
      */
     private void enqueueEvent(Map<String, Object> event) {
         // Push it onto the queue
@@ -445,25 +462,27 @@ public class ParselyTracker {
         }
     }
 
-    /*!  \brief Flush events to Parsely.
-     *
-     *  Empties the event queue and sends the appropriate requests to Parsely.
-     *  Called automatically after a number of seconds determined by `flushInterval`.
-     *
-     *  To make sure all of the queued events are flushed to Parse.ly's servers,
-     * include a call to `flushEventQueue` in your main activity's `onDestroy()` method.
+    /**
+     * Flush events to Parsely.
+     * <p>
+     * Empties the event queue and sends the appropriate requests to Parsely.
+     * Called automatically after a number of seconds determined by {@link #getFlushInterval()}.
+     * <p>
+     * To make sure all of the queued events are flushed to Parse.ly's servers,
+     * call this method in your main activity's `onDestroy()` method.
      */
     public void flushEventQueue() {
         // needed for call from MainActivity
         new FlushQueue().execute();
     }
 
-    /*!  \brief Send the batched event request to Parsely.
+    /**
+     * Send the batched event request to Parsely.
+     * <p>
+     * Creates a POST request containing the JSON encoding of the event queue.
+     * Sends this request to Parse.ly servers.
      *
-     *   Creates a POST request containing the JSON encoding of the event queue.
-     *   Sends this request to Parse.ly servers.
-     *
-     *   @param queue The list of event dictionaries to serialize
+     * @param events The list of event dictionaries to serialize
      */
     private void sendBatchRequest(ArrayList<Map<String, Object>> events) {
         if (events == null || events.size() == 0) {
@@ -486,7 +505,8 @@ public class ParselyTracker {
         PLog("POST Data %s", JsonEncode(batchMap));
     }
 
-    /*! \brief Returns whether the network is accessible and Parsely is reachable.
+    /**
+     * Returns whether the network is accessible and Parsely is reachable.
      *
      * @return Whether the network is accessible and Parsely is reachable.
      */
@@ -497,8 +517,8 @@ public class ParselyTracker {
         return netInfo != null && netInfo.isConnectedOrConnecting();
     }
 
-    /*! \brief Save the event queue to persistent storage.
-
+    /**
+     * Save the event queue to persistent storage.
      */
     private synchronized void persistQueue() {
         PLog("Persisting event queue");
@@ -511,7 +531,8 @@ public class ParselyTracker {
         persistObject(storedQueue);
     }
 
-    /*! \brief Get the stored event queue from persistent storage.
+    /**
+     * Get the stored event queue from persistent storage.
      *
      * @return The stored queue of events.
      */
@@ -538,22 +559,23 @@ public class ParselyTracker {
         return storedQueue;
     }
 
-    /*! \brief Delete the stored queue from persistent storage.
-     *
+    /**
+     * Delete the stored queue from persistent storage.
      */
     protected void purgeStoredQueue() {
         persistObject(new ArrayList<Map<String, Object>>());
     }
 
-    /*! \brief Delete an event from the stored queue.
-     *
+    /**
+     * Delete an event from the stored queue.
      */
     private void expelStoredEvent() {
         ArrayList<Map<String, Object>> storedQueue = getStoredQueue();
         storedQueue.remove(0);
     }
 
-    /*! \brief Persist an object to storage.
+    /**
+     * Persist an object to storage.
      *
      * @param o Object to store.
      */
@@ -571,10 +593,11 @@ public class ParselyTracker {
         }
     }
 
-    /*! \brief Encode an event Map as JSON.
+    /**
+     * Encode an event Map as JSON.
      *
      * @param map The Map object to encode as JSON.
-     * @return    The JSON-encoded value of `map`.
+     * @return The JSON-encoded value of `map`.
      */
     private String JsonEncode(Map<String, Object> map) {
         ObjectMapper mapper = new ObjectMapper();
@@ -589,32 +612,35 @@ public class ParselyTracker {
         return ret;
     }
 
-    /*! \brief Start the timer to flush events to Parsely.
-     *
-     *  Instantiates the callback timer responsible for flushing the events queue.
-     *  Can be called before of after `stop`, but has no effect if used before instantiating the
-     *  singleton
+    /**
+     * Start the timer to flush events to Parsely.
+     * <p>
+     * Instantiates the callback timer responsible for flushing the events queue.
+     * Can be called before of after `stop`, but has no effect if used before instantiating the
+     * singleton
      */
     public void startFlushTimer() {
         flushManager.start();
     }
 
-    /*! \brief Returns whether the event queue flush timer is running.
+    /**
+     * Returns whether the event queue flush timer is running.
      *
-     *  @return Whether the event queue flush timer is running.
+     * @return Whether the event queue flush timer is running.
      */
     public boolean flushTimerIsActive() {
         return flushManager.isRunning();
     }
 
-    /*! \brief Stop the event queue flush timer.
-     *
+    /**
+     * Stop the event queue flush timer.
      */
     public void stopFlushTimer() {
         flushManager.stop();
     }
 
-    /*! \brief Read the Parsely UUID from application context or make a new one.
+    /**
+     * Read the Parsely UUID from application context or make a new one.
      *
      * @return The UUID to use for this user.
      */
@@ -625,10 +651,10 @@ public class ParselyTracker {
         return uuid;
     }
 
-    /*! \brief Get the UUID for this user.
-     *
-     * TODO: docs about where we get this UUID from and how.
+    /**
+     * Get the UUID for this user.
      */
+    //TODO: docs about where we get this UUID from and how.
     private String getSiteUuid() {
         String uuid = "";
         try {
@@ -642,8 +668,9 @@ public class ParselyTracker {
         return uuid;
     }
 
-    /*! \brief Collect device-specific info.
-     *
+    /**
+     * Collect device-specific info.
+     * <p>
      * Collects info about the device and user to use in Parsely events.
      */
     private Map<String, String> collectDeviceInfo(@Nullable final String adKey) {
@@ -664,7 +691,8 @@ public class ParselyTracker {
         return dInfo;
     }
 
-    /*! \brief Get the number of events waiting to be flushed to Parsely.
+    /**
+     * Get the number of events waiting to be flushed to Parsely.
      *
      * @return The number of events waiting to be flushed to Parsely.
      */
@@ -672,7 +700,8 @@ public class ParselyTracker {
         return eventQueue.size();
     }
 
-    /*! \brief Get the number of events stored in persistent storage.
+    /**
+     * Get the number of events stored in persistent storage.
      *
      * @return The number of events stored in persistent storage.
      */
@@ -724,7 +753,8 @@ public class ParselyTracker {
         }
     }
 
-    /*! \brief Async task to get adKey for this device.
+    /**
+     * Async task to get adKey for this device.
      */
     private class GetAdKey extends AsyncTask<Void, Void, String> {
         private final Context mContext;
@@ -760,8 +790,9 @@ public class ParselyTracker {
     }
 
 
-    /*! \brief Manager for the event flush timer.
-     *
+    /**
+     * Manager for the event flush timer.
+     * <p>
      * Handles stopping and starting the flush timer. The flush timer
      * controls how often we send events to Parse.ly servers.
      */
@@ -808,11 +839,12 @@ public class ParselyTracker {
         }
     }
 
-    /*! \brief Engagement manager for article and video engagement.
-     *
+    /**
+     * Engagement manager for article and video engagement.
+     * <p>
      * Implemented to handle its own queuing of future executions to accomplish
      * two things:
-     *
+     * <p>
      * 1. Flushing any engaged time before canceling.
      * 2. Progressive backoff for long engagements to save data.
      */

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyVideoMetadata.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyVideoMetadata.java
@@ -7,14 +7,15 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Map;
 
-/* \brief ParselyMetadata for video content.
- *
+/**
+ * ParselyMetadata for video content.
  */
 public class ParselyVideoMetadata extends ParselyMetadata {
 
     public int durationSeconds;
 
-    /* \brief Create a new ParselyVideoMetadata object.
+    /**
+     * Create a new ParselyVideoMetadata object.
      *
      * @param authors         The names of the authors of the video. Up to 10 authors are accepted.
      * @param videoId         Unique identifier for the video. Required.
@@ -42,7 +43,8 @@ public class ParselyVideoMetadata extends ParselyMetadata {
         this.durationSeconds = durationSeconds;
     }
 
-    /* \brief Turn this object into a Map
+    /**
+     * Turn this object into a Map
      *
      * @return a Map object representing the metadata.
      */


### PR DESCRIPTION
Closes #51 

### Description

This PR updates convention of code comments from Doxygen (dropped in 1bb51a3) with Javadoc. The main benefit is convenience for library users in terms of viewing documentation for highlighted code. See here:

| Before | After | 
| --- | --- | 
| <img width="1050" alt="Screenshot 2023-09-14 at 19 38 23" src="https://github.com/Parsely/parsely-android/assets/5845095/0fa2e217-5548-4b95-ab3d-09d1218b8188"> | <img width="1002" alt="Screenshot 2023-09-14 at 19 37 31" src="https://github.com/Parsely/parsely-android/assets/5845095/f20323a9-408c-46bd-a707-737d9b61a742"> |


#### ~Not sharing `javadoc.jar`~

~I decided to not upload `javadoc.jar` as part of the artifact during the release because the source code of the SDK is open, so IDE will get comments directly from the source.~ See https://github.com/Parsely/parsely-android/pull/71#issuecomment-1720750227

### How to test
1. Go to latest build details (https://github.com/Parsely/parsely-android/pull/71/checks)
2. Download build artifact (top right corner)
3. Unzip it
4. Find `parsely-3.0.8-javadoc.jar`
5. Unzip the file
6. Check if `index.html` exist, and has comments. No need to check the content details.