### PR TITLE
build: get version from the latest tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -2,8 +2,6 @@ plugins {
     id 'com.android.library'
 }
 
-ext.VERSION = '3.0.8'
-
 android {
     compileSdkVersion 33
 

--- a/publication.gradle
+++ b/publication.gradle
@@ -9,6 +9,10 @@ def prepareEnvironment() {
     ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
 }
 
+def static getVersionFromGitTag() {
+    return 'git describe --abbrev=0 --tags'.execute().text.trim()
+}
+
 publishing {
     prepareEnvironment()
     repositories {
@@ -29,7 +33,7 @@ publishing {
                 pom {
                     group = 'com.parsely'
                     name = 'parsely'
-                    version = VERSION
+                    version = getVersionFromGitTag()
 
                     description = 'The official Parse.ly Android toolkit'
                     url = 'https://github.com/Parsely/parsely-android'


### PR DESCRIPTION
Instead of hardcoding version in repository files.

Closes: #50 

### Description

This PR is a small improvement to the release process. Instead of updating a hard-coded version, now the version will be determined by the latest Git tag. It saves a little of overhead and number of actions needed to release a new SDK.

#### How to test

1. Checkout this branch
2. Open `publication.gradle`
3. Comment out content of `signing` extension (no need to test artifacts signing)
4. Add a new tag, e.g. `git tag parsely_testing`
5. Run `./gradlew publishToMavenLocal`
6. Open `~/.m2/repository/com/parsely/parsely/`
7. **Assert you can see directory named `parsely_testing`**
8. Open the directory
9. Open `parsely_testing.pom`
10. **Assert you can see `<version>parsely_testing</version>` tag**
11. Remove the tag (`git tag -d parsely_testing`)
12. Run steps 5-10, but look for `3.0.8` version (latest tag)

#### Documentation update
If this PR will be merged, I'll update our internal documentation to reflect this change.