### PR TITLE
Add UUID to each pageview event

### DIFF
--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -365,7 +365,6 @@ public class ParselyTracker {
 
         // Start a new engagement manager for the video.
         @NonNull final Map<String, Object> hbEvent = buildEvent(url, urlRef, "vheartbeat", videoMetadata, extraData, uuid);
-        hbEvent.put(VIDEO_START_ID_KEY, uuid);
         // TODO: Can we remove some metadata fields from this request?
         videoEngagementManager = new EngagementManager(timer, DEFAULT_ENGAGEMENT_INTERVAL_MILLIS, hbEvent);
         videoEngagementManager.start();

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -248,9 +248,7 @@ public class ParselyTracker {
 
         lastPageviewUuid = generatePixelId();
 
-        @NonNull final Map<String, Object> pageviewEvent = buildEvent(url, urlRef, "pageview", urlMetadata, extraData, lastPageviewUuid);
-
-        enqueueEvent(pageviewEvent);
+        enqueueEvent(buildEvent(url, urlRef, "pageview", urlMetadata, extraData, lastPageviewUuid));
     }
 
     /**

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -67,6 +67,7 @@ public class ParselyTracker {
     private static final String ROOT_URL = "https://p1.parsely.com/";
     private static final String UUID_KEY = "parsely-uuid";
     private static final String VIDEO_START_ID_KEY = "vsid";
+    private static final String PAGE_VIEW_ID_KEY = "pvid";
 
     protected ArrayList<Map<String, Object>> eventQueue;
     private final String siteId;
@@ -77,6 +78,8 @@ public class ParselyTracker {
     private final Timer timer;
     private final FlushManager flushManager;
     private EngagementManager engagementManager, videoEngagementManager;
+    @Nullable
+    private String lastPageviewUuid = null;
 
     /**
      * Create a new ParselyTracker instance.
@@ -242,7 +245,14 @@ public class ParselyTracker {
         if (urlRef == null) {
             urlRef = "";
         }
-        enqueueEvent(buildEvent(url, urlRef, "pageview", urlMetadata, extraData, null));
+
+        @NonNull final String uuid = generatePixelId();
+        lastPageviewUuid = uuid;
+
+        @NonNull final Map<String, Object> pageviewEvent = buildEvent(url, urlRef, "pageview", urlMetadata, extraData, null);
+        pageviewEvent.put(PAGE_VIEW_ID_KEY, lastPageviewUuid);
+
+        enqueueEvent(pageviewEvent);
     }
 
     /**
@@ -284,6 +294,7 @@ public class ParselyTracker {
 
         // Start a new EngagementTask
         Map<String, Object> event = buildEvent(url, urlRef, "heartbeat", null, extraData, null);
+        event.put(PAGE_VIEW_ID_KEY, lastPageviewUuid);
         engagementManager = new EngagementManager(timer, DEFAULT_ENGAGEMENT_INTERVAL_MILLIS, event);
         engagementManager.start();
     }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -246,11 +246,9 @@ public class ParselyTracker {
             urlRef = "";
         }
 
-        @NonNull final String uuid = generatePixelId();
-        lastPageviewUuid = uuid;
+        lastPageviewUuid = generatePixelId();
 
-        @NonNull final Map<String, Object> pageviewEvent = buildEvent(url, urlRef, "pageview", urlMetadata, extraData, null);
-        pageviewEvent.put(PAGE_VIEW_ID_KEY, lastPageviewUuid);
+        @NonNull final Map<String, Object> pageviewEvent = buildEvent(url, urlRef, "pageview", urlMetadata, extraData, lastPageviewUuid);
 
         enqueueEvent(pageviewEvent);
     }
@@ -293,8 +291,7 @@ public class ParselyTracker {
         stopEngagement();
 
         // Start a new EngagementTask
-        Map<String, Object> event = buildEvent(url, urlRef, "heartbeat", null, extraData, null);
-        event.put(PAGE_VIEW_ID_KEY, lastPageviewUuid);
+        Map<String, Object> event = buildEvent(url, urlRef, "heartbeat", null, extraData, lastPageviewUuid);
         engagementManager = new EngagementManager(timer, DEFAULT_ENGAGEMENT_INTERVAL_MILLIS, event);
         engagementManager.start();
     }
@@ -460,6 +457,10 @@ public class ParselyTracker {
 
         if (action.equals("videostart") || action.equals("vheartbeat")) {
             event.put(VIDEO_START_ID_KEY, uuid);
+        }
+
+        if (action.equals("pageview") || action.equals("heartbeat")) {
+            event.put(PAGE_VIEW_ID_KEY, uuid);
         }
 
         return event;


### PR DESCRIPTION
Closes: #28 

### Description

This PR is a twin of #73 for `pageview` and `heartbeat` events. It adds a new, internal field `lastPageviewUuid`. See internal discussion about necessity of it: p1696417656257339-slack-C0533SEJ82H

### Test

1. Install example app, open logcat
2. Tap on `Track Url`
3. Tap on `Start Engagement`
4. Wait 30 seconds until you see `[Parsely] POST Data {"events": (...)` log. Copy the JSON part.
5. Wait another 30 seconds until another `[Parsely] POST Data {"events": (...)` log, copy it as well.
6. Check the copied logs:
- there should be one ` "action": "pageview"` event, rest of them should be `"action": "heartbeat"`
- every event from both logs should have `"pvid"` field with the same value


### New payload

<details>
<summary> Click </summary>
<img width="578" alt="Screenshot 2023-10-05 at 18 34 23" src="https://github.com/Parsely/parsely-android/assets/5845095/50dd62e3-e00c-4114-a9fa-eb219fce10de">

</details>