### PR TITLE
build: add developer metadata to Maven publication

### DIFF
--- a/publication.gradle
+++ b/publication.gradle
@@ -49,6 +49,14 @@ publishing {
                         developerConnection = 'scm:git:ssh://github.com/Parsely/parsely-android.git'
                         url = 'https://github.com/Parsely/parsely-android/tree/main'
                     }
+
+                    developers {
+                        developer {
+                            id = 'wzieba'
+                            name = 'Wojtek Zieba'
+                            email = 'wojtek.zieba@automattic.com'
+                        }
+                    }
                 
                     organization {
                         name = 'Parse.ly'


### PR DESCRIPTION
This PR brings back metadata removed in https://github.com/Parsely/parsely-android/pull/68/commits/ba52e8b5e48ea965bc1d538bb6743191f7bed471

### Why?

It's a requirement from Maven Central. Without this, we can't publish a new release.

<img width="576" alt="Screenshot 2023-10-06 at 16 57 44" src="https://github.com/Parsely/parsely-android/assets/5845095/855c2255-6943-4adb-83fe-866a008c6e2d">
