### PR TITLE
Send events automatically on application `onStop`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: gradle
       - name: Build library

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: set up JDK 11
+      - name: set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: '17'

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: set up JDK 11
+      - name: set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: '17'

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -13,7 +13,7 @@ jobs:
       - name: set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: gradle
       - name: Build library

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -78,12 +78,6 @@ public class MainActivity extends Activity {
 
     }
 
-    @Override
-    protected void onDestroy() {
-        ParselyTracker.sharedInstance().flushEventQueue();
-        super.onDestroy();
-    }
-
     private void updateEngagementStrings() {
         StringBuilder eMsg = new StringBuilder("Engagement is ");
         if (ParselyTracker.sharedInstance().engagementIsActive() == true) {
@@ -150,6 +144,4 @@ public class MainActivity extends Activity {
     }
 
     public void trackReset(View view) {ParselyTracker.sharedInstance().resetVideo(); }
-
-    public void flushEventQueue(View view) {ParselyTracker.sharedInstance().flushEventQueue(); }
 }

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -68,20 +68,11 @@
         android:onClick="trackReset"
         android:text="@string/button_reset_video" />
 
-    <Button
-        android:id="@+id/flush_events_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_below="@+id/reset_video_button"
-        android:layout_centerHorizontal="true"
-        android:onClick="flushEventQueue"
-        android:text="@string/button_flush_event_queue" />
-
     <TextView
         android:id="@+id/queue_size"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/flush_events_button"
+        android:layout_below="@+id/reset_video_button"
         android:layout_centerHorizontal="true"
         android:text="Queued events: 0" />
 

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -8,6 +8,5 @@
     <string name="button_track_video">Track Video</string>
     <string name="button_pause_video">Pause Video</string>
     <string name="button_reset_video">Reset Video</string>
-    <string name="button_flush_event_queue">Flush Event Queue</string>
 
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,6 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
 
 android.disableAutomaticComponentCreation=true
 android.useAndroidX=true
+
+android.experimental.lint.version=8.1.0
+

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -30,9 +30,24 @@ android {
 }
 
 dependencies {
+    def kotlinVersion = "1.8.10"
+
     implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
+    implementation 'androidx.lifecycle:lifecycle-process:2.6.2'
+    constraints {
+        add("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jdk7") {
+            version {
+                require(kotlinVersion)
+            }
+        }
+        add("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jdk8") {
+            version {
+                require(kotlinVersion)
+            }
+        }
+    }
 }
 
 apply from: "${rootProject.projectDir}/publication.gradle"

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -495,17 +495,12 @@ public class ParselyTracker {
     }
 
     /**
-     * Flush events to Parsely.
-     * <p>
-     * Empties the event queue and sends the appropriate requests to Parsely.
-     * Called automatically after a number of seconds determined by {@link #getFlushInterval()}.
-     * <p>
-     * To make sure all of the queued events are flushed to Parse.ly's servers,
-     * call this method in your main activity's `onDestroy()` method.
+     * Deprecated since 3.1.1. The SDK now automatically flushes the queue on app lifecycle events.
+     * Any usage of this method is safe to remove and will have no effect. Keeping for backwards compatibility.
      */
+    @Deprecated
     public void flushEventQueue() {
-        // needed for call from MainActivity
-        new FlushQueue().execute();
+        // no-op
     }
 
     /**

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -24,6 +24,9 @@ import android.os.AsyncTask;
 import android.provider.Settings.Secure;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.ProcessLifecycleOwner;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.android.gms.ads.identifier.AdvertisingIdClient;
@@ -102,6 +105,14 @@ public class ParselyTracker {
         if (getStoredQueue().size() > 0) {
             startFlushTimer();
         }
+
+        ProcessLifecycleOwner.get().getLifecycle().addObserver(
+                (LifecycleEventObserver) (lifecycleOwner, event) -> {
+                    if (event == Lifecycle.Event.ON_STOP) {
+                        new FlushQueue().execute();
+                    }
+                }
+        );
     }
 
     /**

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -109,7 +109,7 @@ public class ParselyTracker {
         ProcessLifecycleOwner.get().getLifecycle().addObserver(
                 (LifecycleEventObserver) (lifecycleOwner, event) -> {
                     if (event == Lifecycle.Event.ON_STOP) {
-                        new FlushQueue().execute();
+                        flushEvents();
                     }
                 }
         );
@@ -846,7 +846,7 @@ public class ParselyTracker {
 
             runningTask = new TimerTask() {
                 public void run() {
-                    new FlushQueue().execute();
+                    flushEvents();
                 }
             };
             parentTimer.scheduleAtFixedRate(runningTask, intervalMillis, intervalMillis);
@@ -869,6 +869,10 @@ public class ParselyTracker {
         public long getIntervalMillis() {
             return intervalMillis;
         }
+    }
+
+    private void flushEvents() {
+        new FlushQueue().execute();
     }
 
     /**

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -851,7 +851,7 @@ public class ParselyTracker {
 
             runningTask = new TimerTask() {
                 public void run() {
-                    flushEventQueue();
+                    new FlushQueue().execute();
                 }
             };
             parentTimer.scheduleAtFixedRate(runningTask, intervalMillis, intervalMillis);


### PR DESCRIPTION
Closes: #76 

## Description

This PR introduces a new behavior of automatically flushing the events queue using `ProcessLifecycleOwner`. This API is used in e.g. [`AppLifecycleIntegration.kt`](https://github.com/getsentry/sentry-java/blob/main/sentry-android-core/src/main/java/io/sentry/android/core/AppLifecycleIntegration.java#L95) from Sentry Android SDK which works similarly to Parse.ly SDK in the sense of observing application lifecycle.

At the same time, this PR deprecates manual queue flushing.

## How to test

### Before
1. Checkout `main`
2. Install and run example app
3. Tap "track URL"
4. Move app to the background (don't kill)
5. After ~20 seconds, you should see `POST Data {"events":` log

### After
1. Checkout this branch
2. Install and run example app
3. Tap "track URL"
4. Move app to the background (don't kill)
5. See that `POST Data {"events":` log is logged imidiatelly after app is moved to the background

## Dependency change report 

```diff
 \--- androidx.appcompat:appcompat:1.4.2
      +--- androidx.core:core:1.7.0
-     |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.4.0
-     |    |    +--- androidx.arch.core:core-runtime:2.1.0
-     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
-     |    |    |    \--- androidx.arch.core:core-common:2.1.0
-     |    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.3.0
-     |    |    +--- androidx.lifecycle:lifecycle-common:2.4.0
-     |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.3.0
-     |    |    +--- androidx.arch.core:core-common:2.1.0 (*)
-     |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.2
+     |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    |    +--- androidx.arch.core:core-common:2.2.0
+     |    |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    |    +--- androidx.arch.core:core-runtime:2.2.0
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    |    |    \--- androidx.arch.core:core-common:2.2.0 (*)
+     |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10
+     |    |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10
+     |    |    |    |    \--- org.jetbrains:annotations:13.0
+     |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4
+     |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4
+     |    |    |    |    |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4
+     |    |    |    |    |         +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4
+     |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (c)
+     |    |    |    |    |         |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4 (c)
+     |    |    |    |    |         |    \--- org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4 (c)
+     |    |    |    |    |         +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10
+     |    |    |    |    |         |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    |    |    |    |         |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10
+     |    |    |    |    |         |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    |    |    |    |         \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.6.21 -> 1.8.10
+     |    |    |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-bom:1.6.4 (*)
+     |    |    |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.21 -> 1.8.10 (*)
+     |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
+     |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
+     |    |    +--- androidx.profileinstaller:profileinstaller:1.3.0
+     |    |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.3.0
+     |    |    |    +--- androidx.concurrent:concurrent-futures:1.1.0
+     |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    |    |    |    \--- com.google.guava:listenablefuture:1.0
+     |    |    |    +--- androidx.startup:startup-runtime:1.1.1
+     |    |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    |    |    |    \--- androidx.tracing:tracing:1.0.0
+     |    |    |    |         \--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    |    |    \--- com.google.guava:listenablefuture:1.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
+     |    |    \--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
-     |    \--- androidx.concurrent:concurrent-futures:1.0.0
-     |         +--- com.google.guava:listenablefuture:1.0
-     |         \--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    \--- androidx.concurrent:concurrent-futures:1.0.0 -> 1.1.0 (*)
      +--- androidx.activity:activity:1.2.4
-     |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.4.0 (*)
+     |    +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.2 (*)
-     |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.1
-     |    |    \--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.1 -> 2.6.2
+     |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
+     |    |    \--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
-     |    +--- androidx.savedstate:savedstate:1.1.0
-     |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
-     |    |    +--- androidx.arch.core:core-common:2.0.1 -> 2.1.0 (*)
-     |    |    \--- androidx.lifecycle:lifecycle-common:2.0.0 -> 2.4.0 (*)
+     |    +--- androidx.savedstate:savedstate:1.1.0 -> 1.2.1
+     |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+     |    |    +--- androidx.lifecycle:lifecycle-common:2.6.1 -> 2.6.2 (*)
+     |    |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
-     |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1
-     |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.3.0
-     |    |    +--- androidx.savedstate:savedstate:1.1.0 (*)
-     |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.1
-     |    |    |    +--- androidx.arch.core:core-common:2.1.0 (*)
-     |    |    |    +--- androidx.arch.core:core-runtime:2.1.0 (*)
-     |    |    |    \--- androidx.lifecycle:lifecycle-common:2.3.1 -> 2.4.0 (*)
-     |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.3.1 (*)
+     |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1 -> 2.6.2
+     |    |    +--- androidx.annotation:annotation:1.0.0 -> 1.3.0
+     |    |    +--- androidx.core:core-ktx:1.2.0
+     |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.3.41 -> 1.8.10 (*)
+     |    |    |    +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    |    |    \--- androidx.core:core:1.2.0 -> 1.7.0 (*)
+     |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2
+     |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+     |    |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
+     |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (*)
+     |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
+     |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (*)
+     |    |    +--- androidx.savedstate:savedstate:1.2.1 (*)
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    |    +--- org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4 (*)
+     |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
+     |    |    \--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
-     |    \--- androidx.tracing:tracing:1.0.0
-     |         \--- androidx.annotation:annotation:1.1.0 -> 1.3.0
+     |    \--- androidx.tracing:tracing:1.0.0 (*)
      +--- androidx.fragment:fragment:1.3.6
      |    +--- androidx.loader:loader:1.0.0
-     |    |    +--- androidx.lifecycle:lifecycle-livedata:2.0.0
-     |    |    |    +--- androidx.arch.core:core-runtime:2.0.0 -> 2.1.0 (*)
-     |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.0.0 -> 2.3.1 (*)
-     |    |    |    \--- androidx.arch.core:core-common:2.0.0 -> 2.1.0 (*)
+     |    |    +--- androidx.lifecycle:lifecycle-livedata:2.0.0 -> 2.6.2
+     |    |    |    +--- androidx.arch.core:core-common:2.1.0 -> 2.2.0 (*)
+     |    |    |    +--- androidx.arch.core:core-runtime:2.1.0 -> 2.2.0 (*)
+     |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (*)
+     |    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-process:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+     |    |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
+     |    |    |    \--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
-     |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.0.0 -> 2.3.1 (*)
+     |    |    \--- androidx.lifecycle:lifecycle-viewmodel:2.0.0 -> 2.6.2 (*)
-     |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.1 (*)
+     |    +--- androidx.lifecycle:lifecycle-livedata-core:2.3.1 -> 2.6.2 (*)
-     |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.1 (*)
+     |    +--- androidx.lifecycle:lifecycle-viewmodel:2.3.1 -> 2.6.2 (*)
-     |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1 (*)
+     |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.3.1 -> 2.6.2 (*)
-     |    \--- androidx.savedstate:savedstate:1.1.0 (*)
+     |    \--- androidx.savedstate:savedstate:1.1.0 -> 1.2.1 (*)
-     +--- androidx.savedstate:savedstate:1.1.0 (*)
+     +--- androidx.savedstate:savedstate:1.1.0 -> 1.2.1 (*)
      +--- androidx.emoji2:emoji2:1.0.0
-     |    +--- androidx.lifecycle:lifecycle-process:2.4.0
-     |    |    +--- androidx.lifecycle:lifecycle-runtime:2.4.0 (*)
-     |    |    \--- androidx.startup:startup-runtime:1.0.0
-     |    |         +--- androidx.annotation:annotation:1.1.0 -> 1.3.0
-     |    |         \--- androidx.tracing:tracing:1.0.0 (*)
+     |    +--- androidx.lifecycle:lifecycle-process:2.4.0 -> 2.6.2
+     |    |    +--- androidx.annotation:annotation:1.2.0 -> 1.3.0
+     |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (*)
+     |    |    +--- androidx.startup:startup-runtime:1.1.1 (*)
+     |    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.8.10 (*)
+     |    |    +--- androidx.lifecycle:lifecycle-runtime:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-viewmodel:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-viewmodel-savedstate:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-livedata-core:2.6.2 (c)
+     |    |    +--- androidx.lifecycle:lifecycle-common:2.6.2 (c)
+     |    |    \--- androidx.lifecycle:lifecycle-livedata:2.6.2 (c)
-     |    \--- androidx.startup:startup-runtime:1.0.0 (*)
+     |    \--- androidx.startup:startup-runtime:1.0.0 -> 1.1.1 (*)
-     +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.4.0 (*)
+     +--- androidx.lifecycle:lifecycle-runtime:2.3.1 -> 2.6.2 (*)
-     \--- androidx.lifecycle:lifecycle-viewmodel:2.3.1 (*)
+     \--- androidx.lifecycle:lifecycle-viewmodel:2.3.1 -> 2.6.2 (*)
++--- androidx.lifecycle:lifecycle-process:2.6.2 (*)
++--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10 (c)
+\--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10 (c)
```