### PR TITLE
Add unit tests to `ParselyAPIConnection` and minor refactor of it

### DIFF
--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 }
 
 apply from: "${rootProject.projectDir}/publication.gradle"

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
@@ -24,7 +24,7 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.net.HttpURLConnection;
 
-class ParselyAPIConnection extends AsyncTask<String, Exception, HttpURLConnection> {
+class ParselyAPIConnection extends AsyncTask<String, Exception, Void> {
 
     @NonNull
     private final ParselyTracker tracker;
@@ -35,7 +35,7 @@ class ParselyAPIConnection extends AsyncTask<String, Exception, HttpURLConnectio
     }
 
     @Override
-    protected HttpURLConnection doInBackground(String... data) {
+    protected Void doInBackground(String... data) {
         HttpURLConnection connection = null;
         try {
             if (data.length == 1) {  // non-batched (since no post data is included)
@@ -54,12 +54,12 @@ class ParselyAPIConnection extends AsyncTask<String, Exception, HttpURLConnectio
 
         } catch (Exception ex) {
             this.exception = ex;
-            return null;
         }
-        return connection;
+        return null;
     }
 
-    protected void onPostExecute(HttpURLConnection conn) {
+    @Override
+    protected void onPostExecute(Void result) {
         if (this.exception != null) {
             ParselyTracker.PLog("Pixel request exception");
             ParselyTracker.PLog(this.exception.toString());

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
@@ -70,10 +70,8 @@ public class ParselyAPIConnection extends AsyncTask<String, Exception, HttpURLCo
                 instance.eventQueue.clear();
                 instance.purgeStoredQueue();
 
-                if (instance.queueSize() == 0 && instance.storedEventsCount() == 0) {
-                    ParselyTracker.PLog("Event queue empty, flush timer cleared.");
-                    instance.stopFlushTimer();
-                }
+                ParselyTracker.PLog("Event queue empty, flush timer cleared.");
+                instance.stopFlushTimer();
             }
         }
     }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
@@ -18,13 +18,21 @@ package com.parsely.parselyandroid;
 
 import android.os.AsyncTask;
 
+import androidx.annotation.NonNull;
+
 import java.io.OutputStream;
 import java.net.URL;
 import java.net.HttpURLConnection;
 
 public class ParselyAPIConnection extends AsyncTask<String, Exception, HttpURLConnection> {
 
+    @NonNull
+    private final ParselyTracker tracker;
     public Exception exception;
+
+    public ParselyAPIConnection(@NonNull ParselyTracker tracker) {
+        this.tracker = tracker;
+    }
 
     @Override
     protected HttpURLConnection doInBackground(String... data) {
@@ -58,21 +66,12 @@ public class ParselyAPIConnection extends AsyncTask<String, Exception, HttpURLCo
         } else {
             ParselyTracker.PLog("Pixel request success");
 
-            ParselyTracker instance = null;
-            try {
-                instance = ParselyTracker.sharedInstance();
-            } catch (NullPointerException ex) {
-                ParselyTracker.PLog("ParselyTracker is null");
-            }
+            // only purge the queue if the request was successful
+            tracker.eventQueue.clear();
+            tracker.purgeStoredQueue();
 
-            if (instance != null) {
-                // only purge the queue if the request was successful
-                instance.eventQueue.clear();
-                instance.purgeStoredQueue();
-
-                ParselyTracker.PLog("Event queue empty, flush timer cleared.");
-                instance.stopFlushTimer();
-            }
+            ParselyTracker.PLog("Event queue empty, flush timer cleared.");
+            tracker.stopFlushTimer();
         }
     }
 }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
@@ -24,13 +24,13 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.net.HttpURLConnection;
 
-public class ParselyAPIConnection extends AsyncTask<String, Exception, HttpURLConnection> {
+class ParselyAPIConnection extends AsyncTask<String, Exception, HttpURLConnection> {
 
     @NonNull
     private final ParselyTracker tracker;
     public Exception exception;
 
-    public ParselyAPIConnection(@NonNull ParselyTracker tracker) {
+    ParselyAPIConnection(@NonNull ParselyTracker tracker) {
         this.tracker = tracker;
     }
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
@@ -28,7 +28,7 @@ class ParselyAPIConnection extends AsyncTask<String, Exception, HttpURLConnectio
 
     @NonNull
     private final ParselyTracker tracker;
-    public Exception exception;
+    private Exception exception;
 
     ParselyAPIConnection(@NonNull ParselyTracker tracker) {
         this.tracker = tracker;

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyAPIConnection.java
@@ -67,8 +67,7 @@ class ParselyAPIConnection extends AsyncTask<String, Exception, HttpURLConnectio
             ParselyTracker.PLog("Pixel request success");
 
             // only purge the queue if the request was successful
-            tracker.eventQueue.clear();
-            tracker.purgeStoredQueue();
+            tracker.purgeEventsQueue();
 
             ParselyTracker.PLog("Event queue empty, flush timer cleared.");
             tracker.stopFlushTimer();

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -458,7 +458,7 @@ public class ParselyTracker {
             eventQueue.clear();
             purgeStoredQueue();
         } else {
-            new ParselyAPIConnection().execute(ROOT_URL + "mobileproxy", JsonEncode(batchMap));
+            new ParselyAPIConnection(this).execute(ROOT_URL + "mobileproxy", JsonEncode(batchMap));
             PLog("Requested %s", ROOT_URL);
         }
         PLog("POST Data %s", JsonEncode(batchMap));

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -455,8 +455,7 @@ public class ParselyTracker {
 
         if (isDebug) {
             PLog("Debug mode on. Not sending to Parse.ly");
-            eventQueue.clear();
-            purgeStoredQueue();
+            purgeEventsQueue();
         } else {
             new ParselyAPIConnection(this).execute(ROOT_URL + "mobileproxy", JsonEncode(batchMap));
             PLog("Requested %s", ROOT_URL);
@@ -516,6 +515,11 @@ public class ParselyTracker {
             storedQueue = new ArrayList<>();
         }
         return storedQueue;
+    }
+
+    void purgeEventsQueue() {
+        eventQueue.clear();
+        purgeStoredQueue();
     }
 
     /**

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -525,7 +525,7 @@ public class ParselyTracker {
     /**
      * Delete the stored queue from persistent storage.
      */
-    protected void purgeStoredQueue() {
+    private void purgeStoredQueue() {
         persistObject(new ArrayList<Map<String, Object>>());
     }
 

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -26,6 +26,11 @@ class ParselyAPIConnectionTest {
         sut = ParselyAPIConnection(tracker)
     }
 
+    @After
+    fun tearDown() {
+        mockServer.shutdown()
+    }
+
     @Test
     fun `given successful response, when making connection without any events, then make GET request`() {
         // given
@@ -89,11 +94,6 @@ class ParselyAPIConnectionTest {
         // then
         assertThat(tracker.events).containsExactly(sampleEvents)
         assertThat(tracker.flushTimerStopped).isFalse
-    }
-
-    @After
-    fun tearDown() {
-        mockServer.shutdown()
     }
 
     companion object {

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -60,7 +60,7 @@ class ParselyAPIConnectionTest {
     }
 
     @Test
-    fun `given successful response, when request is made, purge events queue`() {
+    fun `given successful response, when request is made, then purge events queue and stop flush timer`() {
         // given
         mockServer.enqueue(MockResponse().setResponseCode(200))
         FakeTracker.events.add(mapOf("idsite" to "example.com"))
@@ -71,6 +71,7 @@ class ParselyAPIConnectionTest {
 
         // then
         assertThat(FakeTracker.events).isEmpty()
+        assertThat(FakeTracker.flushTimerStopped).isTrue
     }
 
     @Test

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -44,10 +44,13 @@ class ParselyAPIConnectionTest {
 
     @Test
     fun `when making connection with events, then make POST request with JSON Content-Type header`() {
+        // given
+        mockServer.enqueue(MockResponse().setResponseCode(200))
+
         // when
-        sut.execute(
-            mockServer.url("/").toString(), pixelPayload
-        )
+        val url = mockServer.url("/").toString()
+        sut.execute(url, pixelPayload).get()
+        shadowMainLooper().idle();
 
         // then
         assertThat(mockServer.takeRequest()).satisfies({

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -1,0 +1,35 @@
+package com.parsely.parselyandroid
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ParselyAPIConnectionTest {
+
+    private lateinit var sut: ParselyAPIConnection
+
+    @Before
+    fun setUp() {
+        sut = ParselyAPIConnection(FakeTracker)
+    }
+
+    object FakeTracker : ParselyTracker(
+        "siteId",
+        10,
+        ApplicationProvider.getApplicationContext()
+    ) {
+
+        var flushTimerStopped = false
+        val events = mutableListOf<Map<String, Any>>()
+
+        override fun purgeEventsQueue() {
+            events.clear()
+        }
+
+        override fun stopFlushTimer() {
+            flushTimerStopped = true
+        }
+    }
+}

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -75,7 +75,7 @@ class ParselyAPIConnectionTest {
     }
 
     @Test
-    fun `given unsuccessful response, when request is made, do not purge events queue`() {
+    fun `given unsuccessful response, when request is made, then do not purge events queue and do not stop flush timer`() {
         // given
         mockServer.enqueue(MockResponse().setResponseCode(400))
         val sampleEvents = mapOf("idsite" to "example.com")
@@ -87,6 +87,7 @@ class ParselyAPIConnectionTest {
 
         // then
         assertThat(FakeTracker.events).containsExactly(sampleEvents)
+        assertThat(FakeTracker.flushTimerStopped).isFalse
     }
 
     @After

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -97,18 +97,8 @@ class ParselyAPIConnectionTest {
     }
 
     companion object {
-        val pixelPayload = """
-{
-    "events": [
-        {
-            "idsite": "example.com"
-        },
-        {
-            "idsite": "example2.com"
-        }
-    ]
-}            
-""".trimIndent()
+        val pixelPayload: String =
+            this::class.java.getResource("pixel_payload.json")?.readText().orEmpty()
     }
 
     private class FakeTracker : ParselyTracker(

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -28,9 +28,9 @@ class ParselyAPIConnectionTest {
     fun `when making connection without any events, then make GET request`() {
         // given
         mockServer.enqueue(MockResponse().setResponseCode(200))
+        val url = mockServer.url("").toString()
 
         // when
-        val url = mockServer.url("").toString()
         sut.execute(url).get()
         shadowMainLooper().idle();
 
@@ -46,9 +46,9 @@ class ParselyAPIConnectionTest {
     fun `when making connection with events, then make POST request with JSON Content-Type header`() {
         // given
         mockServer.enqueue(MockResponse().setResponseCode(200))
+        val url = mockServer.url("/").toString()
 
         // when
-        val url = mockServer.url("/").toString()
         sut.execute(url, pixelPayload).get()
         shadowMainLooper().idle();
 

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -75,6 +75,22 @@ class ParselyAPIConnectionTest {
         assertThat(FakeTracker.events).isEmpty()
     }
 
+    @Test
+    fun `given unsuccessful response, when request is made, do not purge events queue`() {
+        // given
+        mockServer.enqueue(MockResponse().setResponseCode(400))
+        val sampleEvents = mapOf("idsite" to "example.com")
+        FakeTracker.events.add(sampleEvents)
+        val url = mockServer.url("/").toString()
+
+        // when
+        sut.execute(url).get()
+        shadowMainLooper().idle();
+
+        // then
+        assertThat(FakeTracker.events).containsExactly(sampleEvents)
+    }
+
     @After
     fun tearDown() {
         mockServer.shutdown()

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -18,6 +18,7 @@ class ParselyAPIConnectionTest {
 
     private lateinit var sut: ParselyAPIConnection
     private val mockServer = MockWebServer()
+    private val url = mockServer.url("").toString()
 
     @Before
     fun setUp() {
@@ -28,7 +29,6 @@ class ParselyAPIConnectionTest {
     fun `when making connection without any events, then make GET request`() {
         // given
         mockServer.enqueue(MockResponse().setResponseCode(200))
-        val url = mockServer.url("").toString()
 
         // when
         sut.execute(url).get()
@@ -46,7 +46,6 @@ class ParselyAPIConnectionTest {
     fun `when making connection with events, then make POST request with JSON Content-Type header`() {
         // given
         mockServer.enqueue(MockResponse().setResponseCode(200))
-        val url = mockServer.url("/").toString()
 
         // when
         sut.execute(url, pixelPayload).get()
@@ -65,7 +64,6 @@ class ParselyAPIConnectionTest {
         // given
         mockServer.enqueue(MockResponse().setResponseCode(200))
         FakeTracker.events.add(mapOf("idsite" to "example.com"))
-        val url = mockServer.url("/").toString()
 
         // when
         sut.execute(url).get()
@@ -81,7 +79,6 @@ class ParselyAPIConnectionTest {
         mockServer.enqueue(MockResponse().setResponseCode(400))
         val sampleEvents = mapOf("idsite" to "example.com")
         FakeTracker.events.add(sampleEvents)
-        val url = mockServer.url("/").toString()
 
         // when
         sut.execute(url).get()

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -60,6 +60,21 @@ class ParselyAPIConnectionTest {
         })
     }
 
+    @Test
+    fun `given successful response, when request is made, purge events queue`() {
+        // given
+        mockServer.enqueue(MockResponse().setResponseCode(200))
+        FakeTracker.events.add(mapOf("idsite" to "example.com"))
+        val url = mockServer.url("/").toString()
+
+        // when
+        sut.execute(url).get()
+        shadowMainLooper().idle();
+
+        // then
+        assertThat(FakeTracker.events).isEmpty()
+    }
+
     @After
     fun tearDown() {
         mockServer.shutdown()

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -30,15 +30,43 @@ class ParselyAPIConnectionTest {
         assertThat(mockServer.takeRequest().method).isEqualTo("GET")
     }
 
+    @Test
+    fun `when making connection with events, then make POST request with JSON Content-Type header`() {
+        // when
+        sut.execute(
+            mockServer.url("/").toString(), pixelPayload
+        )
+
+        // then
+        assertThat(mockServer.takeRequest()).satisfies({
+            assertThat(it.method).isEqualTo("POST")
+            assertThat(it.headers["Content-Type"]).isEqualTo("application/json")
+            assertThat(it.body.readUtf8()).isEqualTo(pixelPayload)
+        })
+    }
+
     @After
     fun tearDown() {
         mockServer.shutdown()
     }
 
+    companion object {
+        val pixelPayload = """
+{
+    "events": [
+        {
+            "idsite": "example.com"
+        },
+        {
+            "idsite": "example2.com"
+        }
+    ]
+}            
+""".trimIndent()
+    }
+
     object FakeTracker : ParselyTracker(
-        "siteId",
-        10,
-        ApplicationProvider.getApplicationContext()
+        "siteId", 10, ApplicationProvider.getApplicationContext()
     ) {
 
         var flushTimerStopped = false

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -1,7 +1,12 @@
 package com.parsely.parselyandroid
 
+import android.content.Context
 import androidx.test.core.app.ApplicationProvider
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Before
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -9,10 +14,25 @@ import org.robolectric.RobolectricTestRunner
 class ParselyAPIConnectionTest {
 
     private lateinit var sut: ParselyAPIConnection
+    private val mockServer = MockWebServer()
 
     @Before
     fun setUp() {
         sut = ParselyAPIConnection(FakeTracker)
+    }
+
+    @Test
+    fun `when making connection without any events, then make GET request`() {
+        // when
+        sut.execute(mockServer.url("/").toString())
+
+        // then
+        assertThat(mockServer.takeRequest().method).isEqualTo("GET")
+    }
+
+    @After
+    fun tearDown() {
+        mockServer.shutdown()
     }
 
     object FakeTracker : ParselyTracker(

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyAPIConnectionTest.kt
@@ -26,7 +26,7 @@ class ParselyAPIConnectionTest {
     }
 
     @Test
-    fun `when making connection without any events, then make GET request`() {
+    fun `given successful response, when making connection without any events, then make GET request`() {
         // given
         mockServer.enqueue(MockResponse().setResponseCode(200))
 
@@ -43,7 +43,7 @@ class ParselyAPIConnectionTest {
     }
 
     @Test
-    fun `when making connection with events, then make POST request with JSON Content-Type header`() {
+    fun `given successful response, when making connection with events, then make POST request with JSON Content-Type header`() {
         // given
         mockServer.enqueue(MockResponse().setResponseCode(200))
 

--- a/parsely/src/test/resources/pixel_payload.json
+++ b/parsely/src/test/resources/pixel_payload.json
@@ -1,0 +1,10 @@
+{
+  "events": [
+    {
+      "idsite": "example.com"
+    },
+    {
+      "idsite": "example2.com"
+    }
+  ]
+}


### PR DESCRIPTION
### Description

This PR adds unit tests for `ParselyAPIConnection` and adds some minor refactor to it.

### How to test

Review and running unit tests should be just fine. Due to async nature of, well, `AsyncTask`, you can also verify that each test execution waited for `AsyncTask` to finish. You should see `Pixel request success` or `Pixel request exception` at the end of test logs.