### PR TITLE
Add setup for functional tests. Test sending events over the local variable limit.

### DIFF
--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -66,7 +66,7 @@ jobs:
           avd-name: macOS-avd-x86_64-31
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: ./gradlew :parsely:connectedCheck
+          script: ./gradlew :parsely:connectedDebugAndroidTest
       - name: Publish build artifacts
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -43,3 +43,33 @@ jobs:
         with:
           name: artifact
           path: ~/.m2/repository/com/parsely/parsely/*
+  functional-tests:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+      - name: Functional Tests
+        uses: reactivecircus/android-emulator-runner@v2.28.0
+        with:
+          working-directory: .
+          api-level: 31
+          profile: Nexus 6
+          arch: x86_64
+          force-avd-creation: false
+          avd-name: macOS-avd-x86_64-31
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew :parsely:connectedCheck
+      - name: Publish build artifacts
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: artifact
+          path: ./parsely/build/reports/*

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -4,6 +4,11 @@ plugins {
     id 'org.jetbrains.kotlinx.kover'
 }
 
+ext {
+    assertJVersion = '3.24.2'
+    mockWebServerVersion = '4.12.0'
+}
+
 android {
     compileSdkVersion 33
 
@@ -59,17 +64,17 @@ dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'androidx.lifecycle:lifecycle-process:2.6.2'
-    
+
     testImplementation 'org.robolectric:robolectric:4.10.3'
     testImplementation 'androidx.test:core:1.5.0'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation "com.squareup.okhttp3:mockwebserver:$mockWebServerVersion"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:rules:1.5.0'
-    androidTestImplementation 'org.assertj:assertj-core:3.24.2'
-    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    androidTestImplementation "org.assertj:assertj-core:$assertJVersion"
+    androidTestImplementation "com.squareup.okhttp3:mockwebserver:$mockWebServerVersion"
     androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
 }

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -10,6 +10,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 33
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         release {
@@ -22,6 +24,7 @@ android {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
     }
+    testBuildType "debug"
 
     publishing {
         singleVariant('release') {
@@ -58,6 +61,12 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'org.assertj:assertj-core:3.24.2'
+    androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    androidTestImplementation 'androidx.test:runner:1.5.2'
 }
 
 apply from: "${rootProject.projectDir}/publication.gradle"

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -33,7 +33,6 @@ android {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
     }
-    testBuildType "debug"
 
     publishing {
         singleVariant('release') {

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -12,6 +12,10 @@ android {
         targetSdkVersion 33
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments clearPackageData: 'true'
+    }
+    testOptions {
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }
     buildTypes {
         release {
@@ -67,6 +71,7 @@ dependencies {
     androidTestImplementation 'org.assertj:assertj-core:3.24.2'
     androidTestImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestUtil 'androidx.test:orchestrator:1.4.2'
 }
 
 apply from: "${rootProject.projectDir}/publication.gradle"

--- a/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
+++ b/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
@@ -1,0 +1,24 @@
+package com.parsely.parselyandroid
+
+import android.app.Activity
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Test
+import org.junit.runner.RunWith
+
+
+@RunWith(AndroidJUnit4::class)
+class FunctionalTests {
+
+    private lateinit var parselyTracker: ParselyTracker
+
+    @Test
+    fun appTracksEventsAboveQueueSizeLimit() {
+        ActivityScenario.launch(SampleActivity::class.java).use { scenario ->
+            scenario.onActivity { activity: Activity ->
+            }
+        }
+    }
+
+    class SampleActivity : Activity()
+}

--- a/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
+++ b/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
@@ -3,6 +3,10 @@ package com.parsely.parselyandroid
 import android.app.Activity
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.lang.reflect.Field
+import kotlin.time.Duration.Companion.seconds
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -11,13 +15,36 @@ import org.junit.runner.RunWith
 class FunctionalTests {
 
     private lateinit var parselyTracker: ParselyTracker
+    private val server = MockWebServer()
+    private val url = server.url("/").toString()
 
     @Test
     fun appTracksEventsAboveQueueSizeLimit() {
         ActivityScenario.launch(SampleActivity::class.java).use { scenario ->
             scenario.onActivity { activity: Activity ->
+                server.enqueue(MockResponse().setResponseCode(200))
+                parselyTracker = initializeTracker(activity)
+
+                parselyTracker.trackPageview("url", null, null, null)
+
+                server.takeRequest()
             }
         }
+    }
+
+    private fun initializeTracker(activity: Activity): ParselyTracker {
+        return ParselyTracker.sharedInstance(
+            siteId, flushInterval.inWholeSeconds.toInt(), activity.application
+        ).apply {
+            val f: Field = this::class.java.getDeclaredField("ROOT_URL")
+            f.isAccessible = true
+            f.set(this, url)
+        }
+    }
+
+    private companion object {
+        const val siteId = "123"
+        val flushInterval = 10.seconds
     }
 
     class SampleActivity : Activity()

--- a/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
+++ b/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
@@ -4,12 +4,19 @@ import android.app.Activity
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import java.io.File
+import java.io.FileInputStream
+import java.io.ObjectInputStream
 import java.lang.reflect.Field
 import java.nio.file.Path
+import java.nio.file.StandardWatchEventKinds.ENTRY_CREATE
+import java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY
+import java.nio.file.WatchEvent
+import java.nio.file.WatchService
 import kotlin.io.path.Path
 import kotlin.time.Duration.Companion.seconds
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -30,6 +37,11 @@ class FunctionalTests {
         }
     }
 
+    /**
+     * In this scenario, the consumer application tracks more than 50 events-threshold during a flush interval.
+     * The SDK will save the events to disk and send them in the next flush interval.
+     * At the end, when all events are sent, the SDK will delete the content of local storage file.
+     */
     @Test
     fun appTracksEventsAboveQueueSizeLimit() {
         ActivityScenario.launch(SampleActivity::class.java).use { scenario ->
@@ -38,11 +50,66 @@ class FunctionalTests {
                 server.enqueue(MockResponse().setResponseCode(200))
                 parselyTracker = initializeTracker(activity)
 
-                parselyTracker.trackPageview("url", null, null, null)
+                repeat(51) {
+                    parselyTracker.trackPageview("url", null, null, null)
+                }
 
-                server.takeRequest()
+                // Waits for the SDK to save events to disk
+                val createLocalStorageEvents = appsFiles.waitForFileEvents(2)
+                assertThat(createLocalStorageEvents).satisfiesExactly(
+                    // Checks for local storage file creation
+                    { event -> assertThat(event.kind()).isEqualTo(ENTRY_CREATE) },
+                    // Checks if local storage file was modified
+                    { event -> assertThat(event.kind()).isEqualTo(ENTRY_MODIFY) },
+                )
+                assertThat(locallyStoredEvents).hasSize(51)
+            }
+
+            val dropLocalStorageEvent = appsFiles.waitForFileEvents(1)
+
+            // Waits for the SDK to send events (flush interval passes)
+            server.takeRequest()
+
+            assertThat(dropLocalStorageEvent).satisfiesExactly(
+                { event -> assertThat(event.kind()).isEqualTo(ENTRY_MODIFY) },
+            )
+            assertThat(locallyStoredEvents).hasSize(0)
+        }
+    }
+
+    private val locallyStoredEvents
+        get() = FileInputStream(File("$appsFiles/parsely-events.ser")).use {
+            ObjectInputStream(it).use { objectInputStream ->
+                @Suppress("UNCHECKED_CAST")
+                objectInputStream.readObject() as ArrayList<Map<String, Any>>
             }
         }
+
+
+    private fun Path.waitForFileEvents(numberOfEvents: Int): List<WatchEvent<*>> {
+        val service = watch()
+        val events = LinkedHashSet<WatchEvent<*>>()
+        while (true) {
+            val key = service.poll()
+            val polledEvents =
+                key?.pollEvents()?.filter { it.context().toString() == "parsely-events.ser" }
+                    .orEmpty()
+            events.addAll(polledEvents)
+            println("[Parsely] Caught ${events.size} file events")
+            if (events.size == numberOfEvents) {
+                key?.reset()
+                break
+            }
+            Thread.sleep(500)
+        }
+        return events.toList()
+    }
+
+    private fun Path.watch(): WatchService {
+        val watchService = this.fileSystem.newWatchService()
+        register(watchService, ENTRY_CREATE, ENTRY_MODIFY)
+
+        return watchService
     }
 
     private fun initializeTracker(activity: Activity): ParselyTracker {

--- a/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
+++ b/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
@@ -38,7 +38,7 @@ class FunctionalTests {
     private fun beforeEach(activity: Activity) {
         appsFiles = Path(activity.filesDir.path)
 
-        if (File("$appsFiles/parsely-events.ser").exists()) {
+        if (File("$appsFiles/$localStorageFileName").exists()) {
             throw RuntimeException("Local storage file exists. Something went wrong with orchestrating the tests.")
         }
     }
@@ -91,7 +91,7 @@ class FunctionalTests {
     )
 
     private val locallyStoredEvents
-        get() = FileInputStream(File("$appsFiles/parsely-events.ser")).use {
+        get() = FileInputStream(File("$appsFiles/$localStorageFileName")).use {
             ObjectInputStream(it).use { objectInputStream ->
                 @Suppress("UNCHECKED_CAST")
                 objectInputStream.readObject() as ArrayList<Map<String, Any>>
@@ -110,6 +110,7 @@ class FunctionalTests {
 
     private companion object {
         const val siteId = "123"
+        const val localStorageFileName = "parsely-events.ser"
         val flushInterval = 10.seconds
     }
 

--- a/parsely/src/debug/AndroidManifest.xml
+++ b/parsely/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.parsely.parselyandroid">
+
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <application
+        android:usesCleartextTraffic="true">
+        <activity android:name=".FunctionalTests$SampleActivity"/>
+    </application>
+
+</manifest>

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -59,9 +59,8 @@ public class ParselyTracker {
     private static final int QUEUE_SIZE_LIMIT = 50;
     private static final int STORAGE_SIZE_LIMIT = 100;
     private static final String STORAGE_KEY = "parsely-events.ser";
-// emulator localhost
-//    private static final String ROOT_URL = "http://10.0.2.2:5001/";
     @SuppressWarnings("StringOperationCanBeSimplified")
+//    private static final String ROOT_URL = "http://10.0.2.2:5001/".intern(); // emulator localhost
     private static final String ROOT_URL = "https://p1.parsely.com/".intern();
     protected ArrayList<Map<String, Object>> eventQueue;
     private boolean isDebug;

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -61,9 +61,7 @@ public class ParselyTracker {
     private static final String STORAGE_KEY = "parsely-events.ser";
 // emulator localhost
 //    private static final String ROOT_URL = "http://10.0.2.2:5001/";
-    /**
-     * @noinspection StringOperationCanBeSimplified
-     */
+    @SuppressWarnings("StringOperationCanBeSimplified")
     private static final String ROOT_URL = "https://p1.parsely.com/".intern();
     protected ArrayList<Map<String, Object>> eventQueue;
     private boolean isDebug;

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -61,7 +61,10 @@ public class ParselyTracker {
     private static final String STORAGE_KEY = "parsely-events.ser";
 // emulator localhost
 //    private static final String ROOT_URL = "http://10.0.2.2:5001/";
-    private static final String ROOT_URL = "https://p1.parsely.com/";
+    /**
+     * @noinspection StringOperationCanBeSimplified
+     */
+    private static final String ROOT_URL = "https://p1.parsely.com/".intern();
     protected ArrayList<Map<String, Object>> eventQueue;
     private boolean isDebug;
     private final Context context;


### PR DESCRIPTION
## Description

This PR adds a setup for writing and running functional tests on CI. Contrary to unit tests, they are meant to be written via black-box technique. The only mocked/faked element of the setup is API, which is intentionally mocked via MockWebServer.

Additionally, it adds a test case for tracking number of events exceeding maximum number of events that are stored in memory. This asserts correctness of saving/querying data from the local file as well as shows the benefits of functional tests.

### Note

Important pivot how to approach the proposed test was made in 8d4a0d39e04b57a6a05bb260e6978e23905c7c12 so please don't pay a lot of attention to implementation details introduced in commit before, which is e97a7a5c3c9ffd2bf75b6b986969e231e021a09a.

## How to test

Green light on CI should be enough. You can also download the build artifact and see results of instrumentation tests.