### PR TITLE
Add functional test for validating consumer application `ON_STOP`

### DIFF
--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     androidTestImplementation "org.assertj:assertj-core:$assertJVersion"
     androidTestImplementation "com.squareup.okhttp3:mockwebserver:$mockWebServerVersion"
     androidTestImplementation 'androidx.test:runner:1.5.2'
+    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
     androidTestUtil 'androidx.test:orchestrator:1.4.2'
 }
 

--- a/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
+++ b/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
@@ -77,8 +77,13 @@ class FunctionalTests {
     }
 
     /**
-     * In this scenario, the consumer application goes to the background, re-launches the app,
-     * and moves to the background again. It asserts, that only one payload has been sent.
+     * In this scenario, the consumer application:
+     * 1. Goes to the background
+     * 2. Is re-launched
+     * This pattern occurs twice, which allows us to confirm the following assertions:
+     * 1. The event request is triggered when the consumer application is moved to the background
+     * 2. If the consumer application is sent to the background again within a short interval,
+     * the request is not duplicated.
      */
     @Test
     fun appSendsEventsWhenMovedToBackgroundAndDoesntSendDuplicatedRequestWhenItsMovedToBackgroundAgainQuickly() {


### PR DESCRIPTION
### Description

This PR adds a functional test for the scenario described above the test case

### Demo
Visually, it'll look like this:


https://github.com/Parsely/parsely-android/assets/5845095/729afd64-d18c-488b-b85f-d2adc6b1961f

