### PR TITLE
Prepare `ParselyTracker` for Kotlin migration

### DIFF
--- a/parsely/src/main/java/com/parsely/parselyandroid/AdvertisementIdProvider.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/AdvertisementIdProvider.kt
@@ -3,7 +3,7 @@ package com.parsely.parselyandroid
 import android.content.Context
 import android.provider.Settings
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
-import com.parsely.parselyandroid.Logging.PLog
+import com.parsely.parselyandroid.Logging.log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -19,7 +19,7 @@ internal class AdvertisementIdProvider(
             try {
                 adKey = AdvertisingIdClient.getAdvertisingIdInfo(context).id
             } catch (e: Exception) {
-                PLog("No Google play services or error!")
+                log("No Google play services or error!")
             }
         }
     }
@@ -41,7 +41,7 @@ internal class AndroidIdProvider(private val context: Context) : IdProvider {
         } catch (ex: Exception) {
             null
         }
-        PLog(String.format("Android ID: %s", uuid))
+        log(String.format("Android ID: %s", uuid))
         return uuid
     }
 }

--- a/parsely/src/main/java/com/parsely/parselyandroid/AdvertisementIdProvider.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/AdvertisementIdProvider.kt
@@ -3,6 +3,7 @@ package com.parsely.parselyandroid
 import android.content.Context
 import android.provider.Settings
 import com.google.android.gms.ads.identifier.AdvertisingIdClient
+import com.parsely.parselyandroid.Logging.PLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -18,7 +19,7 @@ internal class AdvertisementIdProvider(
             try {
                 adKey = AdvertisingIdClient.getAdvertisingIdInfo(context).id
             } catch (e: Exception) {
-                ParselyTracker.PLog("No Google play services or error!")
+                PLog("No Google play services or error!")
             }
         }
     }
@@ -40,7 +41,7 @@ internal class AndroidIdProvider(private val context: Context) : IdProvider {
         } catch (ex: Exception) {
             null
         }
-        ParselyTracker.PLog(String.format("Android ID: %s", uuid))
+        PLog(String.format("Android ID: %s", uuid))
         return uuid
     }
 }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ConnectivityStatusProvider.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ConnectivityStatusProvider.kt
@@ -1,0 +1,22 @@
+package com.parsely.parselyandroid
+
+import android.content.Context
+import android.net.ConnectivityManager
+
+internal interface ConnectivityStatusProvider {
+    /**
+     * @return Whether the network is accessible.
+     */
+    fun isReachable(): Boolean
+}
+
+internal class AndroidConnectivityStatusProvider(private val context: Context): ConnectivityStatusProvider {
+
+    override fun isReachable(): Boolean {
+        val cm = context.getSystemService(
+            Context.CONNECTIVITY_SERVICE
+        ) as ConnectivityManager
+        val netInfo = cm.activeNetworkInfo
+        return netInfo != null && netInfo.isConnectedOrConnecting
+    }
+}

--- a/parsely/src/main/java/com/parsely/parselyandroid/DeviceInfoRepository.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/DeviceInfoRepository.kt
@@ -1,6 +1,7 @@
 package com.parsely.parselyandroid
 
 import android.os.Build
+import com.parsely.parselyandroid.Logging.PLog
 
 internal interface DeviceInfoRepository{
     fun collectDeviceInfo(): Map<String, String>
@@ -34,12 +35,12 @@ internal open class AndroidDeviceInfoRepository(
             val adKey = advertisementIdProvider.provide()
             val androidId = androidIdProvider.provide()
 
-            ParselyTracker.PLog("adkey is: %s, uuid is %s", adKey, androidId)
+            PLog("adkey is: %s, uuid is %s", adKey, androidId)
 
             return if (adKey != null) {
                 adKey
             } else {
-                ParselyTracker.PLog("falling back to device uuid")
+                PLog("falling back to device uuid")
                 androidId .orEmpty()
             }
         }

--- a/parsely/src/main/java/com/parsely/parselyandroid/DeviceInfoRepository.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/DeviceInfoRepository.kt
@@ -1,7 +1,7 @@
 package com.parsely.parselyandroid
 
 import android.os.Build
-import com.parsely.parselyandroid.Logging.PLog
+import com.parsely.parselyandroid.Logging.log
 
 internal interface DeviceInfoRepository{
     fun collectDeviceInfo(): Map<String, String>
@@ -35,12 +35,12 @@ internal open class AndroidDeviceInfoRepository(
             val adKey = advertisementIdProvider.provide()
             val androidId = androidIdProvider.provide()
 
-            PLog("adkey is: %s, uuid is %s", adKey, androidId)
+            log("adkey is: %s, uuid is %s", adKey, androidId)
 
             return if (adKey != null) {
                 adKey
             } else {
-                PLog("falling back to device uuid")
+                log("falling back to device uuid")
                 androidId .orEmpty()
             }
         }

--- a/parsely/src/main/java/com/parsely/parselyandroid/EngagementManager.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/EngagementManager.kt
@@ -1,7 +1,6 @@
 package com.parsely.parselyandroid
 
-import com.parsely.parselyandroid.Logging.PLog
-import kotlin.time.Duration
+import com.parsely.parselyandroid.Logging.log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -63,7 +62,7 @@ internal class EngagementManager(
         val event: MutableMap<String, Any> = HashMap(
             baseEvent
         )
-        PLog(String.format("Enqueuing %s event.", event["action"]))
+        log(String.format("Enqueuing %s event.", event["action"]))
 
         // Update `ts` for the event since it's happening right now.
         val baseEventData = (event["data"] as Map<String, Any>?)!!

--- a/parsely/src/main/java/com/parsely/parselyandroid/EngagementManager.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/EngagementManager.kt
@@ -1,5 +1,6 @@
 package com.parsely.parselyandroid
 
+import com.parsely.parselyandroid.Logging.PLog
 import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -62,7 +63,7 @@ internal class EngagementManager(
         val event: MutableMap<String, Any> = HashMap(
             baseEvent
         )
-        ParselyTracker.PLog(String.format("Enqueuing %s event.", event["action"]))
+        PLog(String.format("Enqueuing %s event.", event["action"]))
 
         // Update `ts` for the event since it's happening right now.
         val baseEventData = (event["data"] as Map<String, Any>?)!!

--- a/parsely/src/main/java/com/parsely/parselyandroid/EventsBuilder.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/EventsBuilder.java
@@ -1,6 +1,6 @@
 package com.parsely.parselyandroid;
 
-import static com.parsely.parselyandroid.ParselyTracker.PLog;
+import static com.parsely.parselyandroid.Logging.PLog;
 
 import android.content.Context;
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/EventsBuilder.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/EventsBuilder.java
@@ -1,8 +1,6 @@
 package com.parsely.parselyandroid;
 
-import static com.parsely.parselyandroid.Logging.PLog;
-
-import android.content.Context;
+import static com.parsely.parselyandroid.Logging.log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -44,7 +42,7 @@ class EventsBuilder {
             Map<String, Object> extraData,
             @Nullable String uuid
     ) {
-        PLog("buildEvent called for %s/%s", action, url);
+        log("buildEvent called for %s/%s", action, url);
 
         Calendar now = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/FlushQueue.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/FlushQueue.kt
@@ -1,7 +1,7 @@
 package com.parsely.parselyandroid
 
 import com.parsely.parselyandroid.JsonSerializer.toParselyEventsPayload
-import com.parsely.parselyandroid.Logging.PLog
+import com.parsely.parselyandroid.Logging.log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -19,7 +19,7 @@ internal class FlushQueue(
 
     operator fun invoke(skipSendingEvents: Boolean) {
         if (!connectivityStatusProvider.isReachable()) {
-            PLog("Network unreachable. Not flushing.")
+            log("Network unreachable. Not flushing.")
             return
         }
         scope.launch {
@@ -32,23 +32,23 @@ internal class FlushQueue(
                 }
 
                 if (skipSendingEvents) {
-                    PLog("Debug mode on. Not sending to Parse.ly. Otherwise, would sent ${eventsToSend.size} events")
+                    log("Debug mode on. Not sending to Parse.ly. Otherwise, would sent ${eventsToSend.size} events")
                     repository.remove(eventsToSend)
                     return@launch
                 }
-                PLog("Sending request with %d events", eventsToSend.size)
+                log("Sending request with %d events", eventsToSend.size)
                 val jsonPayload = toParselyEventsPayload(eventsToSend)
-                PLog("POST Data %s", jsonPayload)
-                PLog("Requested %s", ParselyTracker.ROOT_URL)
+                log("POST Data %s", jsonPayload)
+                log("Requested %s", ParselyTracker.ROOT_URL)
                 restClient.send(jsonPayload)
                     .fold(
                         onSuccess = {
-                            PLog("Pixel request success")
+                            log("Pixel request success")
                             repository.remove(eventsToSend)
                         },
                         onFailure = {
-                            PLog("Pixel request exception")
-                            PLog(it.toString())
+                            log("Pixel request exception")
+                            log(it.toString())
                         }
                     )
             }

--- a/parsely/src/main/java/com/parsely/parselyandroid/FlushQueue.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/FlushQueue.kt
@@ -1,6 +1,7 @@
 package com.parsely.parselyandroid
 
 import com.parsely.parselyandroid.JsonSerializer.toParselyEventsPayload
+import com.parsely.parselyandroid.Logging.PLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -18,7 +19,7 @@ internal class FlushQueue(
 
     operator fun invoke(skipSendingEvents: Boolean) {
         if (!connectivityStatusProvider.isReachable()) {
-            ParselyTracker.PLog("Network unreachable. Not flushing.")
+            PLog("Network unreachable. Not flushing.")
             return
         }
         scope.launch {
@@ -31,23 +32,23 @@ internal class FlushQueue(
                 }
 
                 if (skipSendingEvents) {
-                    ParselyTracker.PLog("Debug mode on. Not sending to Parse.ly. Otherwise, would sent ${eventsToSend.size} events")
+                    PLog("Debug mode on. Not sending to Parse.ly. Otherwise, would sent ${eventsToSend.size} events")
                     repository.remove(eventsToSend)
                     return@launch
                 }
-                ParselyTracker.PLog("Sending request with %d events", eventsToSend.size)
+                PLog("Sending request with %d events", eventsToSend.size)
                 val jsonPayload = toParselyEventsPayload(eventsToSend)
-                ParselyTracker.PLog("POST Data %s", jsonPayload)
-                ParselyTracker.PLog("Requested %s", ParselyTracker.ROOT_URL)
+                PLog("POST Data %s", jsonPayload)
+                PLog("Requested %s", ParselyTracker.ROOT_URL)
                 restClient.send(jsonPayload)
                     .fold(
                         onSuccess = {
-                            ParselyTracker.PLog("Pixel request success")
+                            PLog("Pixel request success")
                             repository.remove(eventsToSend)
                         },
                         onFailure = {
-                            ParselyTracker.PLog("Pixel request exception")
-                            ParselyTracker.PLog(it.toString())
+                            PLog("Pixel request exception")
+                            PLog(it.toString())
                         }
                     )
             }

--- a/parsely/src/main/java/com/parsely/parselyandroid/InMemoryBuffer.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/InMemoryBuffer.kt
@@ -1,5 +1,6 @@
 package com.parsely.parselyandroid
 
+import com.parsely.parselyandroid.Logging.PLog
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -22,7 +23,7 @@ internal class InMemoryBuffer(
             while (isActive) {
                 mutex.withLock {
                     if (buffer.isNotEmpty()) {
-                        ParselyTracker.PLog("Persisting ${buffer.size} events")
+                        PLog("Persisting ${buffer.size} events")
                         localStorageRepository.insertEvents(buffer)
                         buffer.clear()
                     }
@@ -35,7 +36,7 @@ internal class InMemoryBuffer(
     fun add(event: Map<String, Any>) {
         coroutineScope.launch {
             mutex.withLock {
-                ParselyTracker.PLog("Event added to buffer")
+                PLog("Event added to buffer")
                 buffer.add(event)
                 onEventAddedListener()
             }

--- a/parsely/src/main/java/com/parsely/parselyandroid/InMemoryBuffer.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/InMemoryBuffer.kt
@@ -1,6 +1,6 @@
 package com.parsely.parselyandroid
 
-import com.parsely.parselyandroid.Logging.PLog
+import com.parsely.parselyandroid.Logging.log
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
@@ -23,7 +23,7 @@ internal class InMemoryBuffer(
             while (isActive) {
                 mutex.withLock {
                     if (buffer.isNotEmpty()) {
-                        PLog("Persisting ${buffer.size} events")
+                        log("Persisting ${buffer.size} events")
                         localStorageRepository.insertEvents(buffer)
                         buffer.clear()
                     }
@@ -36,7 +36,7 @@ internal class InMemoryBuffer(
     fun add(event: Map<String, Any>) {
         coroutineScope.launch {
             mutex.withLock {
-                PLog("Event added to buffer")
+                log("Event added to buffer")
                 buffer.add(event)
                 onEventAddedListener()
             }

--- a/parsely/src/main/java/com/parsely/parselyandroid/LocalStorageRepository.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/LocalStorageRepository.kt
@@ -1,6 +1,7 @@
 package com.parsely.parselyandroid
 
 import android.content.Context
+import com.parsely.parselyandroid.Logging.PLog
 import java.io.EOFException
 import java.io.FileNotFoundException
 import java.io.ObjectInputStream
@@ -34,7 +35,7 @@ internal class LocalStorageRepository(private val context: Context) : QueueRepos
             oos.close()
             fos.close()
         } catch (ex: Exception) {
-            ParselyTracker.PLog("Exception thrown during queue serialization: %s", ex.toString())
+            PLog("Exception thrown during queue serialization: %s", ex.toString())
         }
     }
 
@@ -52,7 +53,7 @@ internal class LocalStorageRepository(private val context: Context) : QueueRepos
         } catch (ex: FileNotFoundException) {
             // Nothing to do here. Means there was no saved queue.
         } catch (ex: Exception) {
-            ParselyTracker.PLog(
+            PLog(
                 "Exception thrown during queue deserialization: %s",
                 ex.toString()
             )

--- a/parsely/src/main/java/com/parsely/parselyandroid/LocalStorageRepository.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/LocalStorageRepository.kt
@@ -1,7 +1,7 @@
 package com.parsely.parselyandroid
 
 import android.content.Context
-import com.parsely.parselyandroid.Logging.PLog
+import com.parsely.parselyandroid.Logging.log
 import java.io.EOFException
 import java.io.FileNotFoundException
 import java.io.ObjectInputStream
@@ -35,7 +35,7 @@ internal class LocalStorageRepository(private val context: Context) : QueueRepos
             oos.close()
             fos.close()
         } catch (ex: Exception) {
-            PLog("Exception thrown during queue serialization: %s", ex.toString())
+            log("Exception thrown during queue serialization: %s", ex.toString())
         }
     }
 
@@ -53,7 +53,7 @@ internal class LocalStorageRepository(private val context: Context) : QueueRepos
         } catch (ex: FileNotFoundException) {
             // Nothing to do here. Means there was no saved queue.
         } catch (ex: Exception) {
-            PLog(
+            log(
                 "Exception thrown during queue deserialization: %s",
                 ex.toString()
             )

--- a/parsely/src/main/java/com/parsely/parselyandroid/Logging.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/Logging.kt
@@ -8,7 +8,7 @@ object Logging {
      * Log a message to the console.
      */
     @JvmStatic
-    fun PLog(logString: String, vararg objects: Any?) {
+    fun log(logString: String, vararg objects: Any?) {
         if (logString == "") {
             return
         }

--- a/parsely/src/main/java/com/parsely/parselyandroid/Logging.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/Logging.kt
@@ -1,0 +1,17 @@
+package com.parsely.parselyandroid
+
+import java.util.Formatter
+
+object Logging {
+
+    /**
+     * Log a message to the console.
+     */
+    @JvmStatic
+    fun PLog(logString: String, vararg objects: Any?) {
+        if (logString == "") {
+            return
+        }
+        println(Formatter().format("[Parsely] $logString", *objects).toString())
+    }
+}

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -16,7 +16,7 @@
 
 package com.parsely.parselyandroid;
 
-import static com.parsely.parselyandroid.Logging.PLog;
+import static com.parsely.parselyandroid.Logging.log;
 
 import android.content.Context;
 
@@ -83,7 +83,7 @@ public class ParselyTracker {
         inMemoryBuffer = new InMemoryBuffer(ParselyCoroutineScopeKt.getSdkScope(), localStorageRepository, () -> {
             if (!flushTimerIsActive()) {
                 startFlushTimer();
-                PLog("Flush flushTimer set to %ds", (flushManager.getIntervalMillis() / 1000));
+                log("Flush flushTimer set to %ds", (flushManager.getIntervalMillis() / 1000));
             }
             return Unit.INSTANCE;
         });
@@ -201,7 +201,7 @@ public class ParselyTracker {
      */
     public void setDebug(boolean debug) {
         isDebug = debug;
-        PLog("Debugging is now set to " + isDebug);
+        log("Debugging is now set to " + isDebug);
     }
 
     /**

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -16,9 +16,9 @@
 
 package com.parsely.parselyandroid;
 
+import static com.parsely.parselyandroid.Logging.PLog;
+
 import android.content.Context;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -26,7 +26,6 @@ import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleEventObserver;
 import androidx.lifecycle.ProcessLifecycleOwner;
 
-import java.util.Formatter;
 import java.util.Map;
 import java.util.UUID;
 
@@ -145,16 +144,6 @@ public class ParselyTracker {
             instance = new ParselyTracker(siteId, flushInterval, c);
         }
         return instance;
-    }
-
-    /**
-     * Log a message to the console.
-     */
-    static void PLog(String logString, Object... objects) {
-        if (logString.equals("")) {
-            return;
-        }
-        System.out.println(new Formatter().format("[Parsely] " + logString, objects).toString());
     }
 
     /**

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -206,15 +206,6 @@ public class ParselyTracker {
     }
 
     /**
-     * Getter for isDebug
-     *
-     * @return Whether debug mode is active.
-     */
-    public boolean getDebug() {
-        return isDebug;
-    }
-
-    /**
      * Set a debug flag which will prevent data from being sent to Parse.ly
      * <p>
      * Use this flag when developing to prevent the SDK from actually sending requests

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -46,7 +46,6 @@ public class ParselyTracker {
 //    static final String ROOT_URL = "http://10.0.2.2:5001/".intern(); // emulator localhost
     static final String ROOT_URL = "https://p1.parsely.com/".intern();
     private boolean isDebug;
-    private final Context context;
     private final FlushManager flushManager;
     private EngagementManager engagementManager, videoEngagementManager;
     @Nullable
@@ -68,7 +67,7 @@ public class ParselyTracker {
      * Create a new ParselyTracker instance.
      */
     protected ParselyTracker(String siteId, int flushInterval, Context c) {
-        context = c.getApplicationContext();
+        Context context = c.getApplicationContext();
         eventsBuilder = new EventsBuilder(
                 new AndroidDeviceInfoRepository(
                         new AdvertisementIdProvider(context, ParselyCoroutineScopeKt.getSdkScope()),

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -57,8 +57,6 @@ public class ParselyTracker {
     @NonNull
     private final HeartbeatIntervalCalculator intervalCalculator;
     @NonNull
-    private final LocalStorageRepository localStorageRepository;
-    @NonNull
     private final InMemoryBuffer inMemoryBuffer;
     @NonNull
     private final FlushQueue flushQueue;
@@ -73,7 +71,7 @@ public class ParselyTracker {
                         new AdvertisementIdProvider(context, ParselyCoroutineScopeKt.getSdkScope()),
                         new AndroidIdProvider(context)
                 ), siteId);
-        localStorageRepository = new LocalStorageRepository(context);
+        LocalStorageRepository localStorageRepository = new LocalStorageRepository(context);
         flushManager = new ParselyFlushManager(new Function0<Unit>() {
             @Override
             public Unit invoke() {

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -222,7 +222,8 @@ public class ParselyTracker {
             @Nullable ParselyMetadata urlMetadata,
             @Nullable Map<String, Object> extraData) {
         if (url.equals("")) {
-            throw new IllegalArgumentException("url cannot be null or empty.");
+            log("url cannot be empty");
+            return;
         }
 
         // Blank urlref is better than null
@@ -262,7 +263,8 @@ public class ParselyTracker {
             final @Nullable Map<String, Object> extraData
     ) {
         if (url.equals("")) {
-            throw new IllegalArgumentException("url cannot be null or empty.");
+            log("url cannot be empty");
+            return;
         }
 
         // Blank urlref is better than null
@@ -320,7 +322,8 @@ public class ParselyTracker {
             @NonNull ParselyVideoMetadata videoMetadata,
             @Nullable Map<String, Object> extraData) {
         if (url.equals("")) {
-            throw new IllegalArgumentException("url cannot be null or empty.");
+            log("url cannot be empty");
+            return;
         }
 
         // Blank urlref is better than null

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -91,7 +91,7 @@ public class ParselyTracker {
             }
             return Unit.INSTANCE;
         });
-        flushQueue = new FlushQueue(flushManager, localStorageRepository, new ParselyAPIConnection(ROOT_URL + "mobileproxy"), ParselyCoroutineScopeKt.getSdkScope());
+        flushQueue = new FlushQueue(flushManager, localStorageRepository, new ParselyAPIConnection(ROOT_URL + "mobileproxy"), ParselyCoroutineScopeKt.getSdkScope(), new AndroidConnectivityStatusProvider(context));
         clock = new Clock();
         intervalCalculator = new HeartbeatIntervalCalculator(clock);
 
@@ -435,18 +435,6 @@ public class ParselyTracker {
     }
 
     /**
-     * Returns whether the network is accessible and Parsely is reachable.
-     *
-     * @return Whether the network is accessible and Parsely is reachable.
-     */
-    private boolean isReachable() {
-        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(
-                Context.CONNECTIVITY_SERVICE);
-        NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        return netInfo != null && netInfo.isConnectedOrConnecting();
-    }
-
-    /**
      * Start the timer to flush events to Parsely.
      * <p>
      * Instantiates the callback timer responsible for flushing the events queue.
@@ -472,10 +460,6 @@ public class ParselyTracker {
     }
 
     void flushEvents() {
-        if (!isReachable()) {
-            PLog("Network unreachable. Not flushing.");
-            return;
-        }
         flushQueue.invoke(isDebug);
     }
 }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.java
@@ -162,16 +162,18 @@ public class ParselyTracker {
      *
      * @return The base engagement tracking interval.
      */
-    public double getEngagementInterval() {
+    @Nullable
+    public Double getEngagementInterval() {
         if (engagementManager == null) {
-            return -1;
+            return null;
         }
         return engagementManager.getIntervalMillis();
     }
 
-    public double getVideoEngagementInterval() {
+    @Nullable
+    public Double getVideoEngagementInterval() {
         if (videoEngagementManager == null) {
-            return -1;
+            return null;
         }
         return videoEngagementManager.getIntervalMillis();
     }

--- a/parsely/src/test/java/com/parsely/parselyandroid/FlushQueueTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/FlushQueueTest.kt
@@ -61,7 +61,7 @@ class FlushQueueTest {
     @Test
     fun `given non-empty local storage, when flushing queue with skipping sending events, then events are not sent and removed from local storage`() =
         runTest {
-            // give
+            // given
             val repository = FakeRepository().apply {
                 insertEvents(listOf(mapOf("test" to 123)))
             }


### PR DESCRIPTION
### Description

This PR is a set of changes that aim to reduce the size of `ParselyTracker` to reduce the responsibilities of this class and make the transition from Java to Kotlin more readable and easier to review.

### Testing

I see no need for manual tests of this PR. Unit and functional tests suite should be just fine.