### PR TITLE
Add optional `pageType` parameter to `ParselyMetadata` class in Android SDK

### DIFF
--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -132,7 +132,8 @@ public class MainActivity extends Activity {
                 "http://example.com/thumbs/video-1234",
                 "Awesome Video #1234",
                 Calendar.getInstance(),
-                90
+                90,
+                "post"
         );
         // NOTE: For videos embedded in an article, "url" should be the URL for that article.
         ParselyTracker.sharedInstance().trackPlay("http://example.com/app-videos", null, metadata, null);

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -132,8 +132,8 @@ public class MainActivity extends Activity {
                 "http://example.com/thumbs/video-1234",
                 "Awesome Video #1234",
                 Calendar.getInstance(),
-                90,
-                "post"
+                "post",
+                90
         );
         // NOTE: For videos embedded in an article, "url" should be the URL for that article.
         ParselyTracker.sharedInstance().trackPlay("http://example.com/app-videos", null, metadata, null);

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyMetadata.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyMetadata.java
@@ -30,6 +30,7 @@ public class ParselyMetadata {
      * @param thumbUrl URL at which the main image for this content is located.
      * @param title    The title of the content.
      * @param pubDate  The date this piece of content was published.
+     * @param pageType The type of page being tracked.
      */
     public ParselyMetadata(
             @Nullable ArrayList<String> authors,
@@ -38,7 +39,8 @@ public class ParselyMetadata {
             @Nullable ArrayList<String> tags,
             @Nullable String thumbUrl,
             @Nullable String title,
-            @Nullable Calendar pubDate
+            @Nullable Calendar pubDate,
+            @Nullable String pageType
     ) {
         this.authors = authors;
         this.link = link;
@@ -47,6 +49,7 @@ public class ParselyMetadata {
         this.thumbUrl = thumbUrl;
         this.title = title;
         this.pubDate = pubDate;
+        this.pageType = pageType;
     }
 
     /**
@@ -76,6 +79,9 @@ public class ParselyMetadata {
         }
         if (this.pubDate != null) {
             output.put("pub_date_tmsp", this.pubDate.getTimeInMillis() / 1000);
+        }
+        if (this.pageType != null) {
+            output.put("page_type", this.pageType);
         }
         return output;
     }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyMetadata.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyMetadata.java
@@ -17,7 +17,7 @@ import java.util.Map;
  */
 public class ParselyMetadata {
     public ArrayList<String> authors, tags;
-    public String link, section, thumbUrl, title;
+    public String link, section, thumbUrl, title, pageType;
     public Calendar pubDate;
 
     /**

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyVideoMetadata.java
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyVideoMetadata.java
@@ -34,9 +34,10 @@ public class ParselyVideoMetadata extends ParselyMetadata {
             @Nullable String thumbUrl,
             @Nullable String title,
             @Nullable Calendar pubDate,
+            @Nullable String pageType,
             @NonNull int durationSeconds
     ) {
-        super(authors, videoId, section, tags, thumbUrl, title, pubDate);
+        super(authors, videoId, section, tags, thumbUrl, title, pubDate, pageType);
         if (videoId == null) {
             throw new NullPointerException("videoId cannot be null");
         }


### PR DESCRIPTION
## ⁉️ What ⁉️

This PR adds a new optional parameter, `pageType`, to the `ParselyMetadata` class in the Android SDK. This is being done in response to a client question/request (see linked issue below). 

Companion iOS SDK PR: https://github.com/Parsely/AnalyticsSDK-iOS/pull/90

## 🤔 Why 🤔
Resolves https://github.com/Parsely/web/issues/13450

## ✔️ TODOs ✔️
- [x] Attend Chris' office hours to figure out how to test this change
- [x] Get an understanding of how our Android SDK releases are handled before getting this PR merged 