### PR TITLE
Improve how `ParselyTracker` is accessed

### DIFF
--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -25,7 +25,7 @@ public class MainActivity extends Activity {
         setContentView(R.layout.activity_main);
 
         // initialize the Parsely tracker with your site id and the current Context
-        ParselyTracker.sharedInstance("example.com", 30, this, true);
+        ParselyTracker.init("example.com", 30, this, true);
 
         final TextView intervalView = (TextView) findViewById(R.id.interval);
 

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -39,8 +39,8 @@ public class MainActivity extends Activity {
             public void handleMessage(Message msg) {
                 TextView[] v = (TextView[]) msg.obj;
                 TextView iView = v[0];
-                if (ParselyTracker.sharedInstance().flushTimerIsActive()) {
-                    iView.setText(String.format("Flush Interval: %d", ParselyTracker.sharedInstance().getFlushInterval()));
+                if (ParselyTracker.flushTimerIsActive()) {
+                    iView.setText(String.format("Flush Interval: %d", ParselyTracker.getFlushInterval()));
                 } else {
                     iView.setText("Flush timer inactive");
                 }
@@ -62,23 +62,23 @@ public class MainActivity extends Activity {
 
     private void updateEngagementStrings() {
         StringBuilder eMsg = new StringBuilder("Engagement is ");
-        if (ParselyTracker.sharedInstance().engagementIsActive() == true) {
+        if (ParselyTracker.engagementIsActive()) {
             eMsg.append("active.");
         } else {
             eMsg.append("inactive.");
         }
-        eMsg.append(String.format(" (interval: %.01fms)", ParselyTracker.sharedInstance().getEngagementInterval()));
+        eMsg.append(String.format(" (interval: %.01fms)", ParselyTracker.getEngagementInterval()));
 
         TextView eView = findViewById(R.id.et_interval);
         eView.setText(eMsg.toString());
 
         StringBuilder vMsg = new StringBuilder("Video is ");
-        if (ParselyTracker.sharedInstance().videoIsActive() == true) {
+        if (ParselyTracker.videoIsActive()) {
             vMsg.append("active.");
         } else {
             vMsg.append("inactive.");
         }
-        vMsg.append(String.format(" (interval: %.01fms)", ParselyTracker.sharedInstance().getVideoEngagementInterval()));
+        vMsg.append(String.format(" (interval: %.01fms)", ParselyTracker.getVideoEngagementInterval()));
 
         TextView vView = findViewById(R.id.video_interval);
         vView.setText(vMsg.toString());
@@ -88,7 +88,7 @@ public class MainActivity extends Activity {
         // NOTE: urlMetadata is only used when "url" has no version accessible outside the app. If
         //       the post has an internet-accessible URL, we will crawl it. urlMetadata is only used
         //       in the case of app-only content that we can't crawl.
-        ParselyTracker.sharedInstance().trackPageview(
+        ParselyTracker.trackPageview(
                 "http://example.com/article1.html", "http://example.com/", null, null
         );
     }
@@ -96,12 +96,12 @@ public class MainActivity extends Activity {
     public void startEngagement(View view) {
         final Map<String, Object> extraData = new HashMap<>();
         extraData.put("product-id", "12345");
-        ParselyTracker.sharedInstance().startEngagement("http://example.com/article1.html", "http://example.com/", extraData);
+        ParselyTracker.startEngagement("http://example.com/article1.html", "http://example.com/", extraData);
         updateEngagementStrings();
     }
 
     public void stopEngagement(View view) {
-        ParselyTracker.sharedInstance().stopEngagement();
+        ParselyTracker.stopEngagement();
         updateEngagementStrings();
     }
 
@@ -117,13 +117,13 @@ public class MainActivity extends Activity {
                 90
         );
         // NOTE: For videos embedded in an article, "url" should be the URL for that article.
-        ParselyTracker.sharedInstance().trackPlay("http://example.com/app-videos", null, metadata, null);
+        ParselyTracker.trackPlay("http://example.com/app-videos", null, metadata, null);
 
     }
 
     public void trackPause(View view) {
-        ParselyTracker.sharedInstance().trackPause();
+        ParselyTracker.trackPause();
     }
 
-    public void trackReset(View view) {ParselyTracker.sharedInstance().resetVideo(); }
+    public void trackReset(View view) {ParselyTracker.resetVideo(); }
 }

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -39,8 +39,8 @@ public class MainActivity extends Activity {
             public void handleMessage(Message msg) {
                 TextView[] v = (TextView[]) msg.obj;
                 TextView iView = v[0];
-                if (ParselyTracker.flushTimerIsActive()) {
-                    iView.setText(String.format("Flush Interval: %d", ParselyTracker.getFlushInterval()));
+                if (ParselyTracker.sharedInstance().flushTimerIsActive()) {
+                    iView.setText(String.format("Flush Interval: %d", ParselyTracker.sharedInstance().getFlushInterval()));
                 } else {
                     iView.setText("Flush timer inactive");
                 }
@@ -62,23 +62,23 @@ public class MainActivity extends Activity {
 
     private void updateEngagementStrings() {
         StringBuilder eMsg = new StringBuilder("Engagement is ");
-        if (ParselyTracker.engagementIsActive()) {
+        if (ParselyTracker.sharedInstance().engagementIsActive()) {
             eMsg.append("active.");
         } else {
             eMsg.append("inactive.");
         }
-        eMsg.append(String.format(" (interval: %.01fms)", ParselyTracker.getEngagementInterval()));
+        eMsg.append(String.format(" (interval: %.01fms)", ParselyTracker.sharedInstance().getEngagementInterval()));
 
         TextView eView = findViewById(R.id.et_interval);
         eView.setText(eMsg.toString());
 
         StringBuilder vMsg = new StringBuilder("Video is ");
-        if (ParselyTracker.videoIsActive()) {
+        if (ParselyTracker.sharedInstance().videoIsActive()) {
             vMsg.append("active.");
         } else {
             vMsg.append("inactive.");
         }
-        vMsg.append(String.format(" (interval: %.01fms)", ParselyTracker.getVideoEngagementInterval()));
+        vMsg.append(String.format(" (interval: %.01fms)", ParselyTracker.sharedInstance().getVideoEngagementInterval()));
 
         TextView vView = findViewById(R.id.video_interval);
         vView.setText(vMsg.toString());
@@ -88,7 +88,7 @@ public class MainActivity extends Activity {
         // NOTE: urlMetadata is only used when "url" has no version accessible outside the app. If
         //       the post has an internet-accessible URL, we will crawl it. urlMetadata is only used
         //       in the case of app-only content that we can't crawl.
-        ParselyTracker.trackPageview(
+        ParselyTracker.sharedInstance().trackPageview(
                 "http://example.com/article1.html", "http://example.com/", null, null
         );
     }
@@ -96,12 +96,12 @@ public class MainActivity extends Activity {
     public void startEngagement(View view) {
         final Map<String, Object> extraData = new HashMap<>();
         extraData.put("product-id", "12345");
-        ParselyTracker.startEngagement("http://example.com/article1.html", "http://example.com/", extraData);
+        ParselyTracker.sharedInstance().startEngagement("http://example.com/article1.html", "http://example.com/", extraData);
         updateEngagementStrings();
     }
 
     public void stopEngagement(View view) {
-        ParselyTracker.stopEngagement();
+        ParselyTracker.sharedInstance().stopEngagement();
         updateEngagementStrings();
     }
 
@@ -117,13 +117,13 @@ public class MainActivity extends Activity {
                 90
         );
         // NOTE: For videos embedded in an article, "url" should be the URL for that article.
-        ParselyTracker.trackPlay("http://example.com/app-videos", null, metadata, null);
+        ParselyTracker.sharedInstance().trackPlay("http://example.com/app-videos", null, metadata, null);
 
     }
 
     public void trackPause(View view) {
-        ParselyTracker.trackPause();
+        ParselyTracker.sharedInstance().trackPause();
     }
 
-    public void trackReset(View view) {ParselyTracker.resetVideo(); }
+    public void trackReset(View view) {ParselyTracker.sharedInstance().resetVideo(); }
 }

--- a/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
+++ b/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class FunctionalTests {
 
+    private lateinit var parselyTracker: ParselyTracker
     private val server = MockWebServer()
     private val url = server.url("/").toString()
     private lateinit var appsFiles: Path
@@ -62,7 +63,7 @@ class FunctionalTests {
                 initializeTracker(activity)
 
                 repeat(51) {
-                    ParselyTracker.trackPageview("url")
+                    parselyTracker.trackPageview("url")
                 }
             }
 
@@ -92,13 +93,13 @@ class FunctionalTests {
                 server.enqueue(MockResponse().setResponseCode(200))
                 initializeTracker(activity)
 
-                ParselyTracker.trackPageview("url")
+                parselyTracker.trackPageview("url")
             }
 
             Thread.sleep((defaultFlushInterval / 2).inWholeMilliseconds)
 
             scenario.onActivity {
-                ParselyTracker.trackPageview("url")
+                parselyTracker.trackPageview("url")
             }
 
             Thread.sleep((defaultFlushInterval / 2).inWholeMilliseconds)
@@ -107,7 +108,7 @@ class FunctionalTests {
             assertThat(firstRequestPayload!!["events"]).hasSize(2)
 
             scenario.onActivity {
-                ParselyTracker.trackPageview("url")
+                parselyTracker.trackPageview("url")
             }
 
             Thread.sleep(defaultFlushInterval.inWholeMilliseconds)
@@ -137,7 +138,7 @@ class FunctionalTests {
                 initializeTracker(activity, flushInterval = 1.hours)
 
                 repeat(20) {
-                    ParselyTracker.trackPageview("url")
+                    parselyTracker.trackPageview("url")
                 }
             }
 
@@ -171,7 +172,7 @@ class FunctionalTests {
                 initializeTracker(activity)
 
                 repeat(eventsToSend) {
-                    ParselyTracker.trackPageview("url")
+                    parselyTracker.trackPageview("url")
                 }
             }
 
@@ -220,12 +221,12 @@ class FunctionalTests {
 
                 // when
                 startTimestamp = System.currentTimeMillis().milliseconds
-                ParselyTracker.trackPageview("url")
-                ParselyTracker.startEngagement(engagementUrl)
+                parselyTracker.trackPageview("url")
+                parselyTracker.startEngagement(engagementUrl)
             }
 
             Thread.sleep((firstInterval + secondInterval + pauseInterval).inWholeMilliseconds)
-            ParselyTracker.stopEngagement()
+            parselyTracker.stopEngagement()
 
             // then
             val request = server.takeRequest(35, TimeUnit.SECONDS)!!.toMap()["events"]!!
@@ -320,6 +321,7 @@ class FunctionalTests {
         ParselyTracker.init(
             siteId, flushInterval.inWholeSeconds.toInt(), activity.application
         )
+        parselyTracker = ParselyTracker.sharedInstance()
     }
 
     private companion object {

--- a/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
+++ b/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
@@ -318,9 +318,10 @@ class FunctionalTests {
         val field: Field = ParselyTrackerInternal::class.java.getDeclaredField("ROOT_URL")
         field.isAccessible = true
         field.set(this, url)
-        return ParselyTracker.sharedInstance(
+        ParselyTracker.init(
             siteId, flushInterval.inWholeSeconds.toInt(), activity.application
         )
+        return ParselyTracker.sharedInstance()!!
     }
 
     private companion object {

--- a/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
+++ b/parsely/src/androidTest/java/com/parsely/parselyandroid/FunctionalTests.kt
@@ -36,7 +36,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class FunctionalTests {
 
-    private lateinit var parselyTracker: ParselyTracker
     private val server = MockWebServer()
     private val url = server.url("/").toString()
     private lateinit var appsFiles: Path
@@ -60,10 +59,10 @@ class FunctionalTests {
             scenario.onActivity { activity: Activity ->
                 beforeEach(activity)
                 server.enqueue(MockResponse().setResponseCode(200))
-                parselyTracker = initializeTracker(activity)
+                initializeTracker(activity)
 
                 repeat(51) {
-                    parselyTracker.trackPageview("url")
+                    ParselyTracker.trackPageview("url")
                 }
             }
 
@@ -91,15 +90,15 @@ class FunctionalTests {
             scenario.onActivity { activity: Activity ->
                 beforeEach(activity)
                 server.enqueue(MockResponse().setResponseCode(200))
-                parselyTracker = initializeTracker(activity)
+                initializeTracker(activity)
 
-                parselyTracker.trackPageview("url")
+                ParselyTracker.trackPageview("url")
             }
 
             Thread.sleep((defaultFlushInterval / 2).inWholeMilliseconds)
 
             scenario.onActivity {
-                parselyTracker.trackPageview("url")
+                ParselyTracker.trackPageview("url")
             }
 
             Thread.sleep((defaultFlushInterval / 2).inWholeMilliseconds)
@@ -108,7 +107,7 @@ class FunctionalTests {
             assertThat(firstRequestPayload!!["events"]).hasSize(2)
 
             scenario.onActivity {
-                parselyTracker.trackPageview("url")
+                ParselyTracker.trackPageview("url")
             }
 
             Thread.sleep(defaultFlushInterval.inWholeMilliseconds)
@@ -135,10 +134,10 @@ class FunctionalTests {
                 beforeEach(activity)
                 server.enqueue(MockResponse().setResponseCode(200))
                 server.enqueue(MockResponse().setResponseCode(200))
-                parselyTracker = initializeTracker(activity, flushInterval = 1.hours)
+                initializeTracker(activity, flushInterval = 1.hours)
 
                 repeat(20) {
-                    parselyTracker.trackPageview("url")
+                    ParselyTracker.trackPageview("url")
                 }
             }
 
@@ -169,10 +168,10 @@ class FunctionalTests {
             scenario.onActivity { activity: Activity ->
                 beforeEach(activity)
                 server.enqueue(MockResponse().setResponseCode(200))
-                parselyTracker = initializeTracker(activity)
+                initializeTracker(activity)
 
                 repeat(eventsToSend) {
-                    parselyTracker.trackPageview("url")
+                    ParselyTracker.trackPageview("url")
                 }
             }
 
@@ -217,16 +216,16 @@ class FunctionalTests {
             scenario.onActivity { activity: Activity ->
                 beforeEach(activity)
                 server.enqueue(MockResponse().setResponseCode(200))
-                parselyTracker = initializeTracker(activity, flushInterval = 30.seconds)
+                initializeTracker(activity, flushInterval = 30.seconds)
 
                 // when
                 startTimestamp = System.currentTimeMillis().milliseconds
-                parselyTracker.trackPageview("url")
-                parselyTracker.startEngagement(engagementUrl)
+                ParselyTracker.trackPageview("url")
+                ParselyTracker.startEngagement(engagementUrl)
             }
 
             Thread.sleep((firstInterval + secondInterval + pauseInterval).inWholeMilliseconds)
-            parselyTracker.stopEngagement()
+            ParselyTracker.stopEngagement()
 
             // then
             val request = server.takeRequest(35, TimeUnit.SECONDS)!!.toMap()["events"]!!
@@ -314,14 +313,13 @@ class FunctionalTests {
     private fun initializeTracker(
         activity: Activity,
         flushInterval: Duration = defaultFlushInterval
-    ): ParselyTracker {
+    )  {
         val field: Field = ParselyTrackerInternal::class.java.getDeclaredField("ROOT_URL")
         field.isAccessible = true
         field.set(this, url)
         ParselyTracker.init(
             siteId, flushInterval.inWholeSeconds.toInt(), activity.application
         )
-        return ParselyTracker.sharedInstance()!!
     }
 
     private companion object {

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyAlreadyInitializedException.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyAlreadyInitializedException.kt
@@ -1,0 +1,4 @@
+package com.parsely.parselyandroid
+
+public class ParselyAlreadyInitializedException() :
+    Exception("Parse.ly SDK has been already initialized. Reinitialization is not supported.")

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyNotInitializedException.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyNotInitializedException.kt
@@ -1,0 +1,3 @@
+package com.parsely.parselyandroid
+
+public class ParselyNotInitializedException(override val message: String?) : Exception()

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyNotInitializedException.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyNotInitializedException.kt
@@ -1,3 +1,4 @@
 package com.parsely.parselyandroid
 
-public class ParselyNotInitializedException(override val message: String?) : Exception()
+public class ParselyNotInitializedException() :
+    Exception("Parse.ly client has not been initialized. Call ParselyTracker#init before using the SDK.")

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -110,7 +110,9 @@ public object ParselyTracker {
         context: Context,
         dryRun: Boolean = false,
     ) {
-        Logging.log("Parse.ly has been already initialized. Previous configuration will be overwritten.")
+        if (instance != null) {
+            Logging.log("Parse.ly has been already initialized. Previous configuration will be overwritten.")
+        }
         instance = ParselyTrackerInternal(siteId, flushInterval, context, dryRun)
     }
 }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -83,17 +83,14 @@ public interface ParselyTracker {
          */
         @JvmStatic
         @JvmOverloads
-        public fun sharedInstance(
+        public fun init(
             siteId: String,
             flushInterval: Int = DEFAULT_FLUSH_INTERVAL_SECS,
             context: Context,
             dryRun: Boolean = false,
-        ): ParselyTracker {
-            return instance ?: run {
-                val newInstance = ParselyTrackerInternal(siteId, flushInterval, context, dryRun)
-                instance = newInstance
-                return newInstance
-            }
+        ) {
+            Logging.log("Parse.ly has been already initialized. Previous configuration will be overwritten.")
+            instance = ParselyTrackerInternal(siteId, flushInterval, context, dryRun)
         }
     }
 }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -16,6 +16,7 @@
 package com.parsely.parselyandroid
 
 import android.content.Context
+import kotlin.jvm.Throws
 
 /**
  * Tracks Parse.ly app views in Android apps
@@ -25,52 +26,72 @@ import android.content.Context
  * flushes the queue to the Parse.ly pixel proxy server.
  */
 public interface ParselyTracker {
-    public val engagementInterval: Double?
-    public val videoEngagementInterval: Double?
-    public val flushInterval: Long
-
-    public fun engagementIsActive(): Boolean
-    public fun videoIsActive(): Boolean
-
-    public fun trackPageview(
-        url: String,
-        urlRef: String = "",
-        urlMetadata: ParselyMetadata? = null,
-        extraData: Map<String, Any>? = null,
-    )
-
-    public fun startEngagement(
-        url: String,
-        urlRef: String = "",
-        extraData: Map<String, Any>? = null
-    )
-
-    public fun stopEngagement()
-
-    public fun trackPlay(
-        url: String,
-        urlRef: String = "",
-        videoMetadata: ParselyVideoMetadata,
-        extraData: Map<String, Any>? = null,
-    )
-    public fun trackPause()
-    public fun resetVideo()
-    public fun flushEventQueue()
-    public fun flushTimerIsActive(): Boolean
 
     public companion object {
         private const val DEFAULT_FLUSH_INTERVAL_SECS = 60
         private var instance: ParselyTrackerInternal? = null
 
-        /**
-         * Singleton instance accessor. Note: This must be called after [.sharedInstance]
-         *
-         * @return The singleton instance
-         */
-        @JvmStatic
-        public fun sharedInstance(): ParselyTracker? {
-            return instance
+        @Throws(ParselyNotInitializedException::class)
+        private fun ensureInitialized(): ParselyTrackerInternal {
+            return instance ?: run {
+                throw ParselyNotInitializedException("Parse.ly client has not been initialized. Call ParselyTracker#init before using the SDK.");
+            }
         }
+
+        public val engagementInterval: Double?
+            @JvmStatic
+            get() = ensureInitialized().engagementInterval
+
+        public val videoEngagementInterval: Double?
+            @JvmStatic
+            get() = ensureInitialized().videoEngagementInterval
+        public val flushInterval: Long
+            @JvmStatic
+            get() = ensureInitialized().flushInterval
+
+        @JvmStatic
+        public fun engagementIsActive(): Boolean = ensureInitialized().engagementIsActive()
+
+        @JvmStatic
+        public fun videoIsActive(): Boolean = ensureInitialized().videoIsActive()
+
+        @JvmStatic
+        public fun trackPageview(
+            url: String,
+            urlRef: String = "",
+            urlMetadata: ParselyMetadata? = null,
+            extraData: Map<String, Any>? = null,
+        ): Unit = ensureInitialized().trackPageview(url, urlRef, urlMetadata, extraData)
+
+        @JvmStatic
+        public fun startEngagement(
+            url: String,
+            urlRef: String = "",
+            extraData: Map<String, Any>? = null
+        ): Unit = ensureInitialized().startEngagement(url, urlRef, extraData)
+
+        @JvmStatic
+        public fun stopEngagement(): Unit = ensureInitialized().stopEngagement()
+
+        @JvmStatic
+        public fun trackPlay(
+            url: String,
+            urlRef: String = "",
+            videoMetadata: ParselyVideoMetadata,
+            extraData: Map<String, Any>? = null,
+        ): Unit = ensureInitialized().trackPlay(url, urlRef, videoMetadata, extraData)
+
+        @JvmStatic
+        public fun trackPause(): Unit = ensureInitialized().trackPause()
+
+        @JvmStatic
+        public fun resetVideo(): Unit = ensureInitialized().resetVideo()
+
+        @JvmStatic
+        public fun flushEventQueue(): Unit = ensureInitialized().flushEventQueue()
+
+        @JvmStatic
+        public fun flushTimerIsActive(): Boolean = ensureInitialized().flushTimerIsActive()
 
         /**
          * Singleton instance factory Note: this must be called before [.sharedInstance]

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -30,7 +30,6 @@ public object ParselyTracker {
     private const val DEFAULT_FLUSH_INTERVAL_SECS = 60
     private var instance: ParselyTrackerInternal? = null
 
-    @Throws(ParselyNotInitializedException::class)
     private fun ensureInitialized(): ParselyTrackerInternal {
         return instance ?: run {
             throw ParselyNotInitializedException("Parse.ly client has not been initialized. Call ParselyTracker#init before using the SDK.");

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -25,93 +25,92 @@ import kotlin.jvm.Throws
  * Accessed as a singleton. Maintains a queue of pageview events in memory and periodically
  * flushes the queue to the Parse.ly pixel proxy server.
  */
-public interface ParselyTracker {
+public object ParselyTracker {
 
-    public companion object {
-        private const val DEFAULT_FLUSH_INTERVAL_SECS = 60
-        private var instance: ParselyTrackerInternal? = null
+    private const val DEFAULT_FLUSH_INTERVAL_SECS = 60
+    private var instance: ParselyTrackerInternal? = null
 
-        @Throws(ParselyNotInitializedException::class)
-        private fun ensureInitialized(): ParselyTrackerInternal {
-            return instance ?: run {
-                throw ParselyNotInitializedException("Parse.ly client has not been initialized. Call ParselyTracker#init before using the SDK.");
-            }
+    @Throws(ParselyNotInitializedException::class)
+    private fun ensureInitialized(): ParselyTrackerInternal {
+        return instance ?: run {
+            throw ParselyNotInitializedException("Parse.ly client has not been initialized. Call ParselyTracker#init before using the SDK.");
         }
+    }
 
-        public val engagementInterval: Double?
-            @JvmStatic
-            get() = ensureInitialized().engagementInterval
-
-        public val videoEngagementInterval: Double?
-            @JvmStatic
-            get() = ensureInitialized().videoEngagementInterval
-        public val flushInterval: Long
-            @JvmStatic
-            get() = ensureInitialized().flushInterval
-
+    public val engagementInterval: Double?
         @JvmStatic
-        public fun engagementIsActive(): Boolean = ensureInitialized().engagementIsActive()
+        get() = ensureInitialized().engagementInterval
 
+    public val videoEngagementInterval: Double?
         @JvmStatic
-        public fun videoIsActive(): Boolean = ensureInitialized().videoIsActive()
+        get() = ensureInitialized().videoEngagementInterval
 
+    public val flushInterval: Long
         @JvmStatic
-        public fun trackPageview(
-            url: String,
-            urlRef: String = "",
-            urlMetadata: ParselyMetadata? = null,
-            extraData: Map<String, Any>? = null,
-        ): Unit = ensureInitialized().trackPageview(url, urlRef, urlMetadata, extraData)
+        get() = ensureInitialized().flushInterval
 
-        @JvmStatic
-        public fun startEngagement(
-            url: String,
-            urlRef: String = "",
-            extraData: Map<String, Any>? = null
-        ): Unit = ensureInitialized().startEngagement(url, urlRef, extraData)
+    @JvmStatic
+    public fun engagementIsActive(): Boolean = ensureInitialized().engagementIsActive()
 
-        @JvmStatic
-        public fun stopEngagement(): Unit = ensureInitialized().stopEngagement()
+    @JvmStatic
+    public fun videoIsActive(): Boolean = ensureInitialized().videoIsActive()
 
-        @JvmStatic
-        public fun trackPlay(
-            url: String,
-            urlRef: String = "",
-            videoMetadata: ParselyVideoMetadata,
-            extraData: Map<String, Any>? = null,
-        ): Unit = ensureInitialized().trackPlay(url, urlRef, videoMetadata, extraData)
+    @JvmStatic
+    public fun trackPageview(
+        url: String,
+        urlRef: String = "",
+        urlMetadata: ParselyMetadata? = null,
+        extraData: Map<String, Any>? = null,
+    ): Unit = ensureInitialized().trackPageview(url, urlRef, urlMetadata, extraData)
 
-        @JvmStatic
-        public fun trackPause(): Unit = ensureInitialized().trackPause()
+    @JvmStatic
+    public fun startEngagement(
+        url: String,
+        urlRef: String = "",
+        extraData: Map<String, Any>? = null
+    ): Unit = ensureInitialized().startEngagement(url, urlRef, extraData)
 
-        @JvmStatic
-        public fun resetVideo(): Unit = ensureInitialized().resetVideo()
+    @JvmStatic
+    public fun stopEngagement(): Unit = ensureInitialized().stopEngagement()
 
-        @JvmStatic
-        public fun flushEventQueue(): Unit = ensureInitialized().flushEventQueue()
+    @JvmStatic
+    public fun trackPlay(
+        url: String,
+        urlRef: String = "",
+        videoMetadata: ParselyVideoMetadata,
+        extraData: Map<String, Any>? = null,
+    ): Unit = ensureInitialized().trackPlay(url, urlRef, videoMetadata, extraData)
 
-        @JvmStatic
-        public fun flushTimerIsActive(): Boolean = ensureInitialized().flushTimerIsActive()
+    @JvmStatic
+    public fun trackPause(): Unit = ensureInitialized().trackPause()
 
-        /**
-         * Singleton instance factory Note: this must be called before [.sharedInstance]
-         *
-         * @param siteId        The Parsely public site id (eg "example.com")
-         * @param flushInterval The interval at which the events queue should flush, in seconds
-         * @param context             The current Android application context
-         * @param dryRun If set to `true`, events **won't** be sent to Parse.ly server
-         * @return The singleton instance
-         */
-        @JvmStatic
-        @JvmOverloads
-        public fun init(
-            siteId: String,
-            flushInterval: Int = DEFAULT_FLUSH_INTERVAL_SECS,
-            context: Context,
-            dryRun: Boolean = false,
-        ) {
-            Logging.log("Parse.ly has been already initialized. Previous configuration will be overwritten.")
-            instance = ParselyTrackerInternal(siteId, flushInterval, context, dryRun)
-        }
+    @JvmStatic
+    public fun resetVideo(): Unit = ensureInitialized().resetVideo()
+
+    @JvmStatic
+    public fun flushEventQueue(): Unit = ensureInitialized().flushEventQueue()
+
+    @JvmStatic
+    public fun flushTimerIsActive(): Boolean = ensureInitialized().flushTimerIsActive()
+
+    /**
+     * Singleton instance factory Note: this must be called before [.sharedInstance]
+     *
+     * @param siteId        The Parsely public site id (eg "example.com")
+     * @param flushInterval The interval at which the events queue should flush, in seconds
+     * @param context             The current Android application context
+     * @param dryRun If set to `true`, events **won't** be sent to Parse.ly server
+     * @return The singleton instance
+     */
+    @JvmStatic
+    @JvmOverloads
+    public fun init(
+        siteId: String,
+        flushInterval: Int = DEFAULT_FLUSH_INTERVAL_SECS,
+        context: Context,
+        dryRun: Boolean = false,
+    ) {
+        Logging.log("Parse.ly has been already initialized. Previous configuration will be overwritten.")
+        instance = ParselyTrackerInternal(siteId, flushInterval, context, dryRun)
     }
 }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -88,9 +88,6 @@ public object ParselyTracker {
     public fun resetVideo(): Unit = ensureInitialized().resetVideo()
 
     @JvmStatic
-    public fun flushEventQueue(): Unit = ensureInitialized().flushEventQueue()
-
-    @JvmStatic
     public fun flushTimerIsActive(): Boolean = ensureInitialized().flushTimerIsActive()
 
     /**

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -68,7 +68,7 @@ public interface ParselyTracker {
         private const val DEFAULT_FLUSH_INTERVAL_SECS = 60
         private var instance: ParselyTrackerInternal? = null
 
-        private fun ensureInitialized(): ParselyTrackerInternal {
+        private fun ensureInitialized(): ParselyTracker {
             return instance ?: run {
                 throw ParselyNotInitializedException()
             }
@@ -98,7 +98,7 @@ public interface ParselyTracker {
         }
 
         @JvmStatic
-        public fun sharedInstance(): ParselyTrackerInternal = ensureInitialized()
+        public fun sharedInstance(): ParselyTracker = ensureInitialized()
 
         @TestOnly
         internal fun tearDown() {

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -16,7 +16,7 @@
 package com.parsely.parselyandroid
 
 import android.content.Context
-import kotlin.jvm.Throws
+import org.jetbrains.annotations.TestOnly
 
 /**
  * Tracks Parse.ly app views in Android apps
@@ -110,5 +110,10 @@ public object ParselyTracker {
             throw ParselyAlreadyInitializedException()
         }
         instance = ParselyTrackerInternal(siteId, flushInterval, context, dryRun)
+    }
+
+    @TestOnly
+    internal fun tearDown() {
+        instance = null
     }
 }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -26,16 +26,48 @@ import org.jetbrains.annotations.TestOnly
  */
 public interface ParselyTracker {
 
+    /**
+     * Get the heartbeat interval
+     *
+     * @return The base engagement tracking interval.
+     */
     public val engagementInterval: Double?
 
     public val videoEngagementInterval: Double?
 
+    /**
+     * Returns the interval at which the event queue is flushed to Parse.ly.
+     *
+     * @return The interval at which the event queue is flushed to Parse.ly.
+     */
     public val flushInterval: Long
 
+    /**
+     * Returns whether the engagement tracker is running.
+     *
+     * @return Whether the engagement tracker is running.
+     */
     public fun engagementIsActive(): Boolean
 
+    /**
+     * Returns whether video tracking is active.
+     *
+     * @return Whether video tracking is active.
+     */
     public fun videoIsActive(): Boolean
 
+    /**
+     * Register a pageview event using a URL and optional metadata.
+     *
+     * @param url         The URL of the article being tracked
+     * (eg: "http://example.com/some-old/article.html")
+     * @param urlRef      Referrer URL associated with this video view.
+     * @param urlMetadata Optional metadata for the URL -- not used in most cases. Only needed
+     * when `url` isn't accessible over the Internet (i.e. app-only
+     * content). Do not use this for **content also hosted on** URLs Parse.ly
+     * would normally crawl.
+     * @param extraData   A Map of additional information to send with the event.
+     */
     public fun trackPageview(
         url: String,
         urlRef: String = "",
@@ -43,14 +75,56 @@ public interface ParselyTracker {
         extraData: Map<String, Any>? = null,
     )
 
+    /**
+     * Start engaged time tracking for the given URL.
+     *
+     *
+     * This starts a timer which will send events to Parse.ly on a regular basis
+     * to capture engaged time for this URL. The value of `url` should be a URL for
+     * which `trackPageview` has been called.
+     *
+     * @param url    The URL to track engaged time for.
+     * @param urlRef Referrer URL associated with this video view.
+     */
     public fun startEngagement(
         url: String,
         urlRef: String = "",
         extraData: Map<String, Any>? = null
     )
 
+    /**
+     * Stop engaged time tracking.
+     *
+     *
+     * Stops the engaged time tracker, sending any accumulated engaged time to Parse.ly.
+     * NOTE: This **must** be called in your `MainActivity` during various Android lifecycle events
+     * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
+     * and Parse.ly values may be inaccurate.
+     */
     public fun stopEngagement()
 
+    /**
+     * Start video tracking.
+     *
+     *
+     * Starts tracking view time for a video being viewed at a given url. Will send a `videostart`
+     * event unless the same url/videoId had previously been paused.
+     * Video metadata must be provided, specifically the video ID and video duration.
+     *
+     *
+     * The `url` value is *not* the URL of a video, but the post which contains the video. If the video
+     * is not embedded in a post, then this should contain a well-formatted URL on the customer's
+     * domain (e.g. http://<CUSTOMERDOMAIN>/app-videos). This URL doesn't need to return a 200 status
+     * when crawled, but must but well-formatted so Parse.ly systems recognize it as belonging to
+     * the customer.
+     *
+     * @param url           URL of post the video is embedded in. If videos is not embedded, a
+     * valid URL for the customer should still be provided.
+     * (e.g. http://<CUSTOMERDOMAIN>/app-videos)
+     * @param urlRef        Referrer URL associated with this video view.
+     * @param videoMetadata Metadata about the video being tracked.
+     * @param extraData     A Map of additional information to send with the event.
+    </CUSTOMERDOMAIN></CUSTOMERDOMAIN> */
     public fun trackPlay(
         url: String,
         urlRef: String = "",
@@ -58,8 +132,34 @@ public interface ParselyTracker {
         extraData: Map<String, Any>? = null,
     )
 
+    /**
+     * Pause video tracking.
+     *
+     *
+     * Pauses video tracking for an ongoing video. If [.trackPlay] is immediately called again for
+     * the same video, a new video start event will not be sent. This models a user pausing a
+     * playing video.
+     *
+     *
+     * NOTE: This or [.resetVideo] **must** be called in your `MainActivity` during various Android lifecycle events
+     * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
+     * and Parse.ly values may be inaccurate.
+     */
     public fun trackPause()
 
+    /**
+     * Reset tracking on a video.
+     *
+     *
+     * Stops video tracking and resets internal state for the video. If [.trackPlay] is immediately
+     * called for the same video, a new video start event is set. This models a user stopping a
+     * video and (on [.trackPlay] being called again) starting it over.
+     *
+     *
+     * NOTE: This or [.trackPause] **must** be called in your `MainActivity` during various Android lifecycle events
+     * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
+     * and Parse.ly values may be inaccurate.
+     */
     public fun resetVideo()
 
     public fun flushTimerIsActive(): Boolean

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -111,7 +111,8 @@ public object ParselyTracker {
         dryRun: Boolean = false,
     ) {
         if (instance != null) {
-            Logging.log("Parse.ly has been already initialized. Previous configuration will be overwritten.")
+            Logging.log("Parse.ly SDK has been already initialized. Reinitialization is not supported.")
+            return
         }
         instance = ParselyTrackerInternal(siteId, flushInterval, context, dryRun)
     }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -32,7 +32,7 @@ public object ParselyTracker {
 
     private fun ensureInitialized(): ParselyTrackerInternal {
         return instance ?: run {
-            throw ParselyNotInitializedException("Parse.ly client has not been initialized. Call ParselyTracker#init before using the SDK.");
+            throw ParselyNotInitializedException();
         }
     }
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -55,6 +55,7 @@ public object ParselyTracker {
     public fun videoIsActive(): Boolean = ensureInitialized().videoIsActive()
 
     @JvmStatic
+    @JvmOverloads
     public fun trackPageview(
         url: String,
         urlRef: String = "",
@@ -63,6 +64,7 @@ public object ParselyTracker {
     ): Unit = ensureInitialized().trackPageview(url, urlRef, urlMetadata, extraData)
 
     @JvmStatic
+    @JvmOverloads
     public fun startEngagement(
         url: String,
         urlRef: String = "",
@@ -73,6 +75,7 @@ public object ParselyTracker {
     public fun stopEngagement(): Unit = ensureInitialized().stopEngagement()
 
     @JvmStatic
+    @JvmOverloads
     public fun trackPlay(
         url: String,
         urlRef: String = "",

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -21,102 +21,88 @@ import org.jetbrains.annotations.TestOnly
 /**
  * Tracks Parse.ly app views in Android apps
  *
- *
  * Accessed as a singleton. Maintains a queue of pageview events in memory and periodically
  * flushes the queue to the Parse.ly pixel proxy server.
  */
-public object ParselyTracker {
-
-    private const val DEFAULT_FLUSH_INTERVAL_SECS = 60
-    private var instance: ParselyTrackerInternal? = null
-
-    private fun ensureInitialized(): ParselyTrackerInternal {
-        return instance ?: run {
-            throw ParselyNotInitializedException();
-        }
-    }
+public interface ParselyTracker {
 
     public val engagementInterval: Double?
-        @JvmStatic
-        get() = ensureInitialized().engagementInterval
 
     public val videoEngagementInterval: Double?
-        @JvmStatic
-        get() = ensureInitialized().videoEngagementInterval
 
     public val flushInterval: Long
-        @JvmStatic
-        get() = ensureInitialized().flushInterval
 
-    @JvmStatic
-    public fun engagementIsActive(): Boolean = ensureInitialized().engagementIsActive()
+    public fun engagementIsActive(): Boolean
 
-    @JvmStatic
-    public fun videoIsActive(): Boolean = ensureInitialized().videoIsActive()
+    public fun videoIsActive(): Boolean
 
-    @JvmStatic
-    @JvmOverloads
     public fun trackPageview(
         url: String,
         urlRef: String = "",
         urlMetadata: ParselyMetadata? = null,
         extraData: Map<String, Any>? = null,
-    ): Unit = ensureInitialized().trackPageview(url, urlRef, urlMetadata, extraData)
+    )
 
-    @JvmStatic
-    @JvmOverloads
     public fun startEngagement(
         url: String,
         urlRef: String = "",
         extraData: Map<String, Any>? = null
-    ): Unit = ensureInitialized().startEngagement(url, urlRef, extraData)
+    )
 
-    @JvmStatic
-    public fun stopEngagement(): Unit = ensureInitialized().stopEngagement()
+    public fun stopEngagement()
 
-    @JvmStatic
-    @JvmOverloads
     public fun trackPlay(
         url: String,
         urlRef: String = "",
         videoMetadata: ParselyVideoMetadata,
         extraData: Map<String, Any>? = null,
-    ): Unit = ensureInitialized().trackPlay(url, urlRef, videoMetadata, extraData)
+    )
 
-    @JvmStatic
-    public fun trackPause(): Unit = ensureInitialized().trackPause()
+    public fun trackPause()
 
-    @JvmStatic
-    public fun resetVideo(): Unit = ensureInitialized().resetVideo()
+    public fun resetVideo()
 
-    @JvmStatic
-    public fun flushTimerIsActive(): Boolean = ensureInitialized().flushTimerIsActive()
+    public fun flushTimerIsActive(): Boolean
 
-    /**
-     * Singleton instance factory Note: this must be called before [.sharedInstance]
-     *
-     * @param siteId        The Parsely public site id (eg "example.com")
-     * @param flushInterval The interval at which the events queue should flush, in seconds
-     * @param context             The current Android application context
-     * @param dryRun If set to `true`, events **won't** be sent to Parse.ly server
-     * @return The singleton instance
-     */
-    @JvmStatic
-    @JvmOverloads
-    public fun init(
-        siteId: String,
-        flushInterval: Int = DEFAULT_FLUSH_INTERVAL_SECS,
-        context: Context,
-        dryRun: Boolean = false,
-    ) {
-        if (instance != null) {
-            throw ParselyAlreadyInitializedException()
+    public companion object {
+        private const val DEFAULT_FLUSH_INTERVAL_SECS = 60
+        private var instance: ParselyTrackerInternal? = null
+
+        private fun ensureInitialized(): ParselyTrackerInternal {
+            return instance ?: run {
+                throw ParselyNotInitializedException()
+            }
         }
-        instance = ParselyTrackerInternal(siteId, flushInterval, context, dryRun)
-    }
 
-    @TestOnly
-    internal fun tearDown() {
-        instance = null
+        /**
+         * Singleton instance factory Note: this must be called before [.sharedInstance]
+         *
+         * @param siteId        The Parsely public site id (eg "example.com")
+         * @param flushInterval The interval at which the events queue should flush, in seconds
+         * @param context             The current Android application context
+         * @param dryRun If set to `true`, events **won't** be sent to Parse.ly server
+         * @return The singleton instance
+         */
+        @JvmStatic
+        @JvmOverloads
+        public fun init(
+            siteId: String,
+            flushInterval: Int = DEFAULT_FLUSH_INTERVAL_SECS,
+            context: Context,
+            dryRun: Boolean = false,
+        ) {
+            if (instance != null) {
+                throw ParselyAlreadyInitializedException()
+            }
+            instance = ParselyTrackerInternal(siteId, flushInterval, context, dryRun)
+        }
+
+        @JvmStatic
+        public fun sharedInstance(): ParselyTrackerInternal = ensureInitialized()
+
+        @TestOnly
+        internal fun tearDown() {
+            instance = null
+        }
     }
 }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -108,8 +108,7 @@ public object ParselyTracker {
         dryRun: Boolean = false,
     ) {
         if (instance != null) {
-            Logging.log("Parse.ly SDK has been already initialized. Reinitialization is not supported.")
-            return
+            throw ParselyAlreadyInitializedException()
         }
         instance = ParselyTrackerInternal(siteId, flushInterval, context, dryRun)
     }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -6,12 +6,12 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ProcessLifecycleOwner
 import java.util.UUID
 
-internal class ParselyTrackerInternal internal constructor(
+public class ParselyTrackerInternal internal constructor(
     siteId: String,
     flushInterval: Int,
     c: Context,
     private val dryRun: Boolean
-) : EventQueuer {
+) : ParselyTracker, EventQueuer {
     private val flushManager: FlushManager
     private var engagementManager: EngagementManager? = null
     private var videoEngagementManager: EngagementManager? = null
@@ -71,10 +71,10 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return The base engagement tracking interval.
      */
-    internal val engagementInterval: Double?
+    override val engagementInterval: Double?
         get() = engagementManager?.intervalMillis
 
-    internal val videoEngagementInterval: Double?
+    override val videoEngagementInterval: Double?
         get() = videoEngagementManager?.intervalMillis
 
     /**
@@ -82,7 +82,7 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return Whether the engagement tracker is running.
      */
-    internal fun engagementIsActive(): Boolean {
+    override fun engagementIsActive(): Boolean {
         return engagementManager?.isRunning ?: false
     }
 
@@ -91,7 +91,7 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return Whether video tracking is active.
      */
-    internal fun videoIsActive(): Boolean {
+    override fun videoIsActive(): Boolean {
         return videoEngagementManager?.isRunning ?: false
     }
 
@@ -100,7 +100,7 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return The interval at which the event queue is flushed to Parse.ly.
      */
-    internal val flushInterval: Long
+    override val flushInterval: Long
         get() = flushManager.intervalMillis / 1000
 
     /**
@@ -115,7 +115,7 @@ internal class ParselyTrackerInternal internal constructor(
      * would normally crawl.
      * @param extraData   A Map of additional information to send with the event.
      */
-    internal fun trackPageview(
+    override fun trackPageview(
         url: String,
         urlRef: String,
         urlMetadata: ParselyMetadata?,
@@ -152,7 +152,7 @@ internal class ParselyTrackerInternal internal constructor(
      * @param url    The URL to track engaged time for.
      * @param urlRef Referrer URL associated with this video view.
      */
-    internal fun startEngagement(
+    override fun startEngagement(
         url: String,
         urlRef: String,
         extraData: Map<String, Any>?
@@ -192,7 +192,7 @@ internal class ParselyTrackerInternal internal constructor(
      * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
      * and Parse.ly values may be inaccurate.
      */
-    internal fun stopEngagement() {
+    override fun stopEngagement() {
         engagementManager?.let {
             it.stop()
             Logging.log("Engagement session has been stopped")
@@ -222,7 +222,7 @@ internal class ParselyTrackerInternal internal constructor(
      * @param videoMetadata Metadata about the video being tracked.
      * @param extraData     A Map of additional information to send with the event.
     </CUSTOMERDOMAIN></CUSTOMERDOMAIN> */
-    internal fun trackPlay(
+    override fun trackPlay(
         url: String,
         urlRef: String,
         videoMetadata: ParselyVideoMetadata,
@@ -279,7 +279,7 @@ internal class ParselyTrackerInternal internal constructor(
      * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
      * and Parse.ly values may be inaccurate.
      */
-    internal fun trackPause() {
+    override fun trackPause() {
         videoEngagementManager?.stop()
     }
 
@@ -296,7 +296,7 @@ internal class ParselyTrackerInternal internal constructor(
      * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
      * and Parse.ly values may be inaccurate.
      */
-    internal fun resetVideo() {
+    override fun resetVideo() {
         videoEngagementManager?.stop()
         videoEngagementManager = null
     }
@@ -328,7 +328,7 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return Whether the event queue flush timer is running.
      */
-    internal fun flushTimerIsActive(): Boolean {
+    override fun flushTimerIsActive(): Boolean {
         return flushManager.isRunning
     }
 
@@ -340,7 +340,7 @@ internal class ParselyTrackerInternal internal constructor(
         flushQueue.invoke(dryRun)
     }
 
-    companion object {
+    internal companion object {
         private const val DEFAULT_ENGAGEMENT_INTERVAL_MILLIS = 10500
         @JvmField val ROOT_URL: String = "https://p1.parsely.com/".intern()
     }

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -71,10 +71,10 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return The base engagement tracking interval.
      */
-    override val engagementInterval: Double?
+    internal val engagementInterval: Double?
         get() = engagementManager?.intervalMillis
 
-    override val videoEngagementInterval: Double?
+    internal val videoEngagementInterval: Double?
         get() = videoEngagementManager?.intervalMillis
 
     /**
@@ -82,7 +82,7 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return Whether the engagement tracker is running.
      */
-    override fun engagementIsActive(): Boolean {
+    internal fun engagementIsActive(): Boolean {
         return engagementManager?.isRunning ?: false
     }
 
@@ -91,7 +91,7 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return Whether video tracking is active.
      */
-    override fun videoIsActive(): Boolean {
+    internal fun videoIsActive(): Boolean {
         return videoEngagementManager?.isRunning ?: false
     }
 
@@ -100,7 +100,7 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return The interval at which the event queue is flushed to Parse.ly.
      */
-    override val flushInterval: Long
+    internal val flushInterval: Long
         get() = flushManager.intervalMillis / 1000
 
     /**
@@ -115,7 +115,7 @@ internal class ParselyTrackerInternal internal constructor(
      * would normally crawl.
      * @param extraData   A Map of additional information to send with the event.
      */
-    override fun trackPageview(
+    internal fun trackPageview(
         url: String,
         urlRef: String,
         urlMetadata: ParselyMetadata?,
@@ -152,7 +152,7 @@ internal class ParselyTrackerInternal internal constructor(
      * @param url    The URL to track engaged time for.
      * @param urlRef Referrer URL associated with this video view.
      */
-    override fun startEngagement(
+    internal fun startEngagement(
         url: String,
         urlRef: String,
         extraData: Map<String, Any>?
@@ -192,7 +192,7 @@ internal class ParselyTrackerInternal internal constructor(
      * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
      * and Parse.ly values may be inaccurate.
      */
-    override fun stopEngagement() {
+    internal fun stopEngagement() {
         engagementManager?.let {
             it.stop()
             Logging.log("Engagement session has been stopped")
@@ -222,7 +222,7 @@ internal class ParselyTrackerInternal internal constructor(
      * @param videoMetadata Metadata about the video being tracked.
      * @param extraData     A Map of additional information to send with the event.
     </CUSTOMERDOMAIN></CUSTOMERDOMAIN> */
-    override fun trackPlay(
+    internal fun trackPlay(
         url: String,
         urlRef: String,
         videoMetadata: ParselyVideoMetadata,
@@ -279,7 +279,7 @@ internal class ParselyTrackerInternal internal constructor(
      * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
      * and Parse.ly values may be inaccurate.
      */
-    override fun trackPause() {
+    internal fun trackPause() {
         videoEngagementManager?.stop()
     }
 
@@ -296,7 +296,7 @@ internal class ParselyTrackerInternal internal constructor(
      * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
      * and Parse.ly values may be inaccurate.
      */
-    override fun resetVideo() {
+    internal fun resetVideo() {
         videoEngagementManager?.stop()
         videoEngagementManager = null
     }
@@ -316,7 +316,7 @@ internal class ParselyTrackerInternal internal constructor(
      * Any usage of this method is safe to remove and will have no effect. Keeping for backwards compatibility.
      */
     @Deprecated("The SDK now automatically flushes the queue on app lifecycle events. Any usage of this method is safe to remove and will have no effect")
-    override fun flushEventQueue() {
+    fun flushEventQueue() {
         // no-op
     }
 
@@ -337,7 +337,7 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return Whether the event queue flush timer is running.
      */
-    override fun flushTimerIsActive(): Boolean {
+    internal fun flushTimerIsActive(): Boolean {
         return flushManager.isRunning
     }
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -11,7 +11,7 @@ internal class ParselyTrackerInternal internal constructor(
     flushInterval: Int,
     c: Context,
     private val dryRun: Boolean
-) : ParselyTracker, EventQueuer {
+) : EventQueuer {
     private val flushManager: FlushManager
     private var engagementManager: EngagementManager? = null
     private var videoEngagementManager: EngagementManager? = null

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -312,15 +312,6 @@ internal class ParselyTrackerInternal internal constructor(
     }
 
     /**
-     * Deprecated since 3.1.1. The SDK now automatically flushes the queue on app lifecycle events.
-     * Any usage of this method is safe to remove and will have no effect. Keeping for backwards compatibility.
-     */
-    @Deprecated("The SDK now automatically flushes the queue on app lifecycle events. Any usage of this method is safe to remove and will have no effect")
-    fun flushEventQueue() {
-        // no-op
-    }
-
-    /**
      * Start the timer to flush events to Parsely.
      *
      *

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ProcessLifecycleOwner
 import java.util.UUID
 
-public class ParselyTrackerInternal internal constructor(
+internal class ParselyTrackerInternal internal constructor(
     siteId: String,
     flushInterval: Int,
     c: Context,

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -66,55 +66,23 @@ internal class ParselyTrackerInternal internal constructor(
         )
     }
 
-    /**
-     * Get the heartbeat interval
-     *
-     * @return The base engagement tracking interval.
-     */
     override val engagementInterval: Double?
         get() = engagementManager?.intervalMillis
 
     override val videoEngagementInterval: Double?
         get() = videoEngagementManager?.intervalMillis
 
-    /**
-     * Returns whether the engagement tracker is running.
-     *
-     * @return Whether the engagement tracker is running.
-     */
     override fun engagementIsActive(): Boolean {
         return engagementManager?.isRunning ?: false
     }
 
-    /**
-     * Returns whether video tracking is active.
-     *
-     * @return Whether video tracking is active.
-     */
     override fun videoIsActive(): Boolean {
         return videoEngagementManager?.isRunning ?: false
     }
 
-    /**
-     * Returns the interval at which the event queue is flushed to Parse.ly.
-     *
-     * @return The interval at which the event queue is flushed to Parse.ly.
-     */
     override val flushInterval: Long
         get() = flushManager.intervalMillis / 1000
 
-    /**
-     * Register a pageview event using a URL and optional metadata.
-     *
-     * @param url         The URL of the article being tracked
-     * (eg: "http://example.com/some-old/article.html")
-     * @param urlRef      Referrer URL associated with this video view.
-     * @param urlMetadata Optional metadata for the URL -- not used in most cases. Only needed
-     * when `url` isn't accessible over the Internet (i.e. app-only
-     * content). Do not use this for **content also hosted on** URLs Parse.ly
-     * would normally crawl.
-     * @param extraData   A Map of additional information to send with the event.
-     */
     override fun trackPageview(
         url: String,
         urlRef: String,
@@ -141,17 +109,6 @@ internal class ParselyTrackerInternal internal constructor(
         )
     }
 
-    /**
-     * Start engaged time tracking for the given URL.
-     *
-     *
-     * This starts a timer which will send events to Parse.ly on a regular basis
-     * to capture engaged time for this URL. The value of `url` should be a URL for
-     * which `trackPageview` has been called.
-     *
-     * @param url    The URL to track engaged time for.
-     * @param urlRef Referrer URL associated with this video view.
-     */
     override fun startEngagement(
         url: String,
         urlRef: String,
@@ -183,15 +140,6 @@ internal class ParselyTrackerInternal internal constructor(
         ).also { it.start() }
     }
 
-    /**
-     * Stop engaged time tracking.
-     *
-     *
-     * Stops the engaged time tracker, sending any accumulated engaged time to Parse.ly.
-     * NOTE: This **must** be called in your `MainActivity` during various Android lifecycle events
-     * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
-     * and Parse.ly values may be inaccurate.
-     */
     override fun stopEngagement() {
         engagementManager?.let {
             it.stop()
@@ -200,28 +148,6 @@ internal class ParselyTrackerInternal internal constructor(
         engagementManager = null
     }
 
-    /**
-     * Start video tracking.
-     *
-     *
-     * Starts tracking view time for a video being viewed at a given url. Will send a `videostart`
-     * event unless the same url/videoId had previously been paused.
-     * Video metadata must be provided, specifically the video ID and video duration.
-     *
-     *
-     * The `url` value is *not* the URL of a video, but the post which contains the video. If the video
-     * is not embedded in a post, then this should contain a well-formatted URL on the customer's
-     * domain (e.g. http://<CUSTOMERDOMAIN>/app-videos). This URL doesn't need to return a 200 status
-     * when crawled, but must but well-formatted so Parse.ly systems recognize it as belonging to
-     * the customer.
-     *
-     * @param url           URL of post the video is embedded in. If videos is not embedded, a
-     * valid URL for the customer should still be provided.
-     * (e.g. http://<CUSTOMERDOMAIN>/app-videos)
-     * @param urlRef        Referrer URL associated with this video view.
-     * @param videoMetadata Metadata about the video being tracked.
-     * @param extraData     A Map of additional information to send with the event.
-    </CUSTOMERDOMAIN></CUSTOMERDOMAIN> */
     override fun trackPlay(
         url: String,
         urlRef: String,
@@ -266,36 +192,10 @@ internal class ParselyTrackerInternal internal constructor(
         ).also { it.start() }
     }
 
-    /**
-     * Pause video tracking.
-     *
-     *
-     * Pauses video tracking for an ongoing video. If [.trackPlay] is immediately called again for
-     * the same video, a new video start event will not be sent. This models a user pausing a
-     * playing video.
-     *
-     *
-     * NOTE: This or [.resetVideo] **must** be called in your `MainActivity` during various Android lifecycle events
-     * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
-     * and Parse.ly values may be inaccurate.
-     */
     override fun trackPause() {
         videoEngagementManager?.stop()
     }
 
-    /**
-     * Reset tracking on a video.
-     *
-     *
-     * Stops video tracking and resets internal state for the video. If [.trackPlay] is immediately
-     * called for the same video, a new video start event is set. This models a user stopping a
-     * video and (on [.trackPlay] being called again) starting it over.
-     *
-     *
-     * NOTE: This or [.trackPause] **must** be called in your `MainActivity` during various Android lifecycle events
-     * like `onPause` or `onStop`. Otherwise, engaged time tracking may keep running in the background
-     * and Parse.ly values may be inaccurate.
-     */
     override fun resetVideo() {
         videoEngagementManager?.stop()
         videoEngagementManager = null

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyTrackerTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyTrackerTest.kt
@@ -1,0 +1,40 @@
+package com.parsely.parselyandroid
+
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ParselyTrackerTest {
+
+    @Test(expected = ParselyNotInitializedException::class)
+    fun `given no prior initialization, when executing a method, throw the exception`() {
+        ParselyTracker.engagementIsActive()
+    }
+
+    @Test(expected = ParselyAlreadyInitializedException::class)
+    fun `given prior initialization, when initializing, throw an exception`() {
+        ParselyTracker.init(siteId = "", context = RuntimeEnvironment.getApplication())
+
+        ParselyTracker.init(siteId = "", context = RuntimeEnvironment.getApplication())
+    }
+
+    @Test
+    fun `given no prior initialization, when initializing, do not throw any exception`() {
+        ParselyTracker.init(siteId = "", context = RuntimeEnvironment.getApplication())
+    }
+
+    @Test
+    fun `given tracker initialized, when calling a method, do not throw any exception`() {
+        ParselyTracker.init(siteId = "", context = RuntimeEnvironment.getApplication())
+
+        ParselyTracker.engagementIsActive()
+    }
+
+    @After
+    fun tearDown() {
+        ParselyTracker.tearDown()
+    }
+}

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyTrackerTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyTrackerTest.kt
@@ -11,7 +11,7 @@ class ParselyTrackerTest {
 
     @Test(expected = ParselyNotInitializedException::class)
     fun `given no prior initialization, when executing a method, throw the exception`() {
-        ParselyTracker.engagementIsActive()
+        ParselyTracker.sharedInstance().engagementIsActive()
     }
 
     @Test(expected = ParselyAlreadyInitializedException::class)
@@ -30,7 +30,7 @@ class ParselyTrackerTest {
     fun `given tracker initialized, when calling a method, do not throw any exception`() {
         ParselyTracker.init(siteId = "", context = RuntimeEnvironment.getApplication())
 
-        ParselyTracker.engagementIsActive()
+        ParselyTracker.sharedInstance().engagementIsActive()
     }
 
     @After


### PR DESCRIPTION
## Description

This PR is addressing 2 review comments from a different PR: https://github.com/Parsely/parsely-android/pull/99#discussion_r1453739601 https://github.com/Parsely/parsely-android/pull/99#discussion_r1453748066

I identify 2 improvement opportunities here:
- confusing SDK initialization and re-initialization problem
- nullability of `sharedInstance()` getter and confusing usage

This PR should address both matters. I'll put details in comments.

## How to test
No need for manual tests.