### PR TITLE
ci: use ubuntu-latest for functional tests. Improve CI caching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
       - name: Build library
         run: ./gradlew :parsely:assembleDebug
       - name: Publish to Maven Central Repository

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -62,6 +62,14 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd
       - name: Functional Tests
         uses: reactivecircus/android-emulator-runner@v2.29.0
         with:

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -44,7 +44,7 @@ jobs:
           name: artifact
           path: ~/.m2/repository/com/parsely/parsely/*
   functional-tests:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -55,8 +55,13 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Functional Tests
-        uses: reactivecircus/android-emulator-runner@v2.28.0
+        uses: reactivecircus/android-emulator-runner@v2.29.0
         with:
           working-directory: .
           api-level: 31

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -15,7 +15,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Build library
         run: ./gradlew :parsely:assembleDebug
       - name: Build example app
@@ -54,7 +55,8 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -96,7 +96,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           disk-size: 4096M
-          script: ./gradlew :parsely:connectedDebugAndroidTest
+          script: adb uninstall "com.parsely.parselyandroid.test"; ./gradlew :parsely:connectedDebugAndroidTest
       - name: Publish build artifacts
         uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -70,8 +70,22 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          working-directory: .
+          api-level: 31
+          profile: Nexus 6
+          arch: x86_64
+          force-avd-creation: false
+          avd-name: macOS-avd-x86_64-31
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          disk-size: 4096M
+          script: echo "Generated AVD snapshot for caching."
       - name: Functional Tests
-        uses: reactivecircus/android-emulator-runner@v2.29.0
+        uses: reactivecircus/android-emulator-runner@v2
         with:
           working-directory: .
           api-level: 31
@@ -81,6 +95,7 @@ jobs:
           avd-name: macOS-avd-x86_64-31
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
+          disk-size: 4096M
           script: ./gradlew :parsely:connectedDebugAndroidTest
       - name: Publish build artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/submit-gradle-dependencies.yml
+++ b/.github/workflows/submit-gradle-dependencies.yml
@@ -1,9 +1,6 @@
 name: Submit dependencies to GitHub Dependency Graph
 on:
   push:
-    branches:
-      - main
-      - release/*
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
## Description

This PR:

- moves running functional tests from macOS to Ubuntu runner as KVM is now enabled on Ubuntu. The improvement is significant - from ~13m to ~5m per run
- delegates caching to `gradle-build-action`
- send dependencies on each push because it helps in tracking closed security alerts
- caches AVD files