### PR TITLE
Remove unneeded methods from api

### DIFF
--- a/example/src/main/java/com/example/InternalDebugOnlyData.java
+++ b/example/src/main/java/com/example/InternalDebugOnlyData.java
@@ -1,0 +1,58 @@
+package com.example;
+
+import com.parsely.parselyandroid.ParselyTrackerInternal;
+
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+/**
+ * The InternalDebugOnlyData class is designed to provide access to internal data for debugging
+ * purposes through reflection. The methods within this class are intended for internal use only
+ * and should *not* be utilized within the SDK user's code.
+ * @noinspection KotlinInternalInJava
+ */
+class InternalDebugOnlyData {
+    private final ParselyTrackerInternal parselyTracker;
+
+    InternalDebugOnlyData(ParselyTrackerInternal parselyTracker) {
+        this.parselyTracker = parselyTracker;
+    }
+
+    boolean engagementIsActive() {
+        return (boolean) invokePrivateMethod("engagementIsActive");
+    }
+
+    @Nullable
+    Double getEngagementInterval() {
+        return (Double) invokePrivateMethod("getEngagementInterval");
+    }
+
+    @Nullable
+    Double getVideoEngagementInterval() {
+        return (Double) invokePrivateMethod("getVideoEngagementInterval");
+    }
+
+    long getFlushInterval() {
+        return (long) invokePrivateMethod("getFlushInterval");
+    }
+
+    boolean videoIsActive() {
+        return (boolean) invokePrivateMethod("videoIsActive");
+    }
+
+    boolean flushTimerIsActive() {
+        return (boolean) invokePrivateMethod("flushTimerIsActive");
+    }
+
+    private Object invokePrivateMethod(String methodName) {
+        try {
+            Method method = ParselyTrackerInternal.class.getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            return method.invoke(parselyTracker);
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -50,7 +50,7 @@ public class MainActivity extends Activity {
                 TextView[] v = (TextView[]) msg.obj;
                 TextView iView = v[0];
                 if (ParselyTracker.sharedInstance().flushTimerIsActive()) {
-                    iView.setText(String.format("Flush Interval: %d", ParselyTracker.sharedInstance().getFlushInterval()));
+                    iView.setText(String.format("Flush Interval: %d", getFlushInterval()));
                 } else {
                     iView.setText("Flush timer inactive");
                 }
@@ -150,6 +150,10 @@ public class MainActivity extends Activity {
     @Nullable
     private Double getVideoEngagementInterval() {
         return (Double) invokePrivateMethod("getVideoEngagementInterval");
+    }
+
+    private long getFlushInterval() {
+        return (long) invokePrivateMethod("getFlushInterval");
     }
 
     private Object invokePrivateMethod(String methodName, Object... args) {

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -49,7 +49,7 @@ public class MainActivity extends Activity {
             public void handleMessage(Message msg) {
                 TextView[] v = (TextView[]) msg.obj;
                 TextView iView = v[0];
-                if (ParselyTracker.sharedInstance().flushTimerIsActive()) {
+                if (flushTimerIsActive()) {
                     iView.setText(String.format("Flush Interval: %d", getFlushInterval()));
                 } else {
                     iView.setText("Flush timer inactive");
@@ -158,6 +158,10 @@ public class MainActivity extends Activity {
 
     private boolean videoIsActive() {
         return (boolean) invokePrivateMethod("videoIsActive");
+    }
+
+    private boolean flushTimerIsActive() {
+        return (boolean) invokePrivateMethod("flushTimerIsActive");
     }
 
     private Object invokePrivateMethod(String methodName, Object... args) {

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -83,7 +83,7 @@ public class MainActivity extends Activity {
         eView.setText(eMsg.toString());
 
         StringBuilder vMsg = new StringBuilder("Video is ");
-        if (parselyTracker.videoIsActive()) {
+        if (videoIsActive()) {
             vMsg.append("active.");
         } else {
             vMsg.append("inactive.");
@@ -154,6 +154,10 @@ public class MainActivity extends Activity {
 
     private long getFlushInterval() {
         return (long) invokePrivateMethod("getFlushInterval");
+    }
+
+    private boolean videoIsActive() {
+        return (boolean) invokePrivateMethod("videoIsActive");
     }
 
     private Object invokePrivateMethod(String methodName, Object... args) {

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -19,6 +19,8 @@ import android.widget.TextView;
 
 import com.parsely.parselyandroid.*;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * @noinspection KotlinInternalInJava
  */
@@ -75,7 +77,7 @@ public class MainActivity extends Activity {
         } else {
             eMsg.append("inactive.");
         }
-        eMsg.append(String.format(" (interval: %.01fms)", parselyTracker.getEngagementInterval()));
+        eMsg.append(String.format(" (interval: %.01fms)", getEngagementInterval()));
 
         TextView eView = findViewById(R.id.et_interval);
         eView.setText(eMsg.toString());
@@ -143,6 +145,17 @@ public class MainActivity extends Activity {
             engagementIsActive = ParselyTrackerInternal.class.getDeclaredMethod("engagementIsActive");
             engagementIsActive.setAccessible(true);
             return (boolean) engagementIsActive.invoke(parselyTracker);
+        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    @Nullable
+    private static Double getEngagementInterval() {
+        try {
+            Method getEngagementInterval = null;
+            getEngagementInterval = ParselyTrackerInternal.class.getDeclaredMethod("getEngagementInterval");
+            getEngagementInterval.setAccessible(true);
+            return (Double) getEngagementInterval.invoke(parselyTracker);
         } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -142,6 +142,7 @@ public class MainActivity extends Activity {
     private boolean engagementIsActive() {
         return (boolean) invokePrivateMethod("engagementIsActive");
     }
+    
     @Nullable
     private Double getEngagementInterval() {
         return (Double) invokePrivateMethod("getEngagementInterval");
@@ -164,11 +165,11 @@ public class MainActivity extends Activity {
         return (boolean) invokePrivateMethod("flushTimerIsActive");
     }
 
-    private Object invokePrivateMethod(String methodName, Object... args) {
+    private Object invokePrivateMethod(String methodName) {
         try {
             Method method = ParselyTrackerInternal.class.getDeclaredMethod(methodName);
             method.setAccessible(true);
-            return method.invoke(parselyTracker, args);
+            return method.invoke(parselyTracker);
         } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -88,7 +88,7 @@ public class MainActivity extends Activity {
         } else {
             vMsg.append("inactive.");
         }
-        vMsg.append(String.format(" (interval: %.01fms)", parselyTracker.getVideoEngagementInterval()));
+        vMsg.append(String.format(" (interval: %.01fms)", getVideoEngagementInterval()));
 
         TextView vView = findViewById(R.id.video_interval);
         vView.setText(vMsg.toString());
@@ -145,6 +145,11 @@ public class MainActivity extends Activity {
     @Nullable
     private Double getEngagementInterval() {
         return (Double) invokePrivateMethod("getEngagementInterval");
+    }
+
+    @Nullable
+    private Double getVideoEngagementInterval() {
+        return (Double) invokePrivateMethod("getVideoEngagementInterval");
     }
 
     private Object invokePrivateMethod(String methodName, Object... args) {

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -127,7 +127,7 @@ public class MainActivity extends Activity {
                 90
         );
         // NOTE: For videos embedded in an article, "url" should be the URL for that article.
-        ParselyTracker.sharedInstance().trackPlay("http://example.com/app-videos", null, metadata, null);
+        ParselyTracker.sharedInstance().trackPlay("http://example.com/app-videos", "", metadata, null);
 
     }
 

--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public class MainActivity extends Activity {
 
-    private static ParselyTracker parselyTracker;
+    private ParselyTracker parselyTracker;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -139,23 +139,19 @@ public class MainActivity extends Activity {
         ParselyTracker.sharedInstance().resetVideo();
     }
 
-    private static boolean engagementIsActive() {
-        try {
-            Method engagementIsActive = null;
-            engagementIsActive = ParselyTrackerInternal.class.getDeclaredMethod("engagementIsActive");
-            engagementIsActive.setAccessible(true);
-            return (boolean) engagementIsActive.invoke(parselyTracker);
-        } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
+    private boolean engagementIsActive() {
+        return (boolean) invokePrivateMethod("engagementIsActive");
     }
     @Nullable
-    private static Double getEngagementInterval() {
+    private Double getEngagementInterval() {
+        return (Double) invokePrivateMethod("getEngagementInterval");
+    }
+
+    private Object invokePrivateMethod(String methodName, Object... args) {
         try {
-            Method getEngagementInterval = null;
-            getEngagementInterval = ParselyTrackerInternal.class.getDeclaredMethod("getEngagementInterval");
-            getEngagementInterval.setAccessible(true);
-            return (Double) getEngagementInterval.invoke(parselyTracker);
+            Method method = ParselyTrackerInternal.class.getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            return method.invoke(parselyTracker, args);
         } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }

--- a/parsely/api/parsely.api
+++ b/parsely/api/parsely.api
@@ -14,11 +14,6 @@ public final class com/parsely/parselyandroid/ParselyNotInitializedException : j
 
 public abstract interface class com/parsely/parselyandroid/ParselyTracker {
 	public static final field Companion Lcom/parsely/parselyandroid/ParselyTracker$Companion;
-	public abstract fun engagementIsActive ()Z
-	public abstract fun flushTimerIsActive ()Z
-	public abstract fun getEngagementInterval ()Ljava/lang/Double;
-	public abstract fun getFlushInterval ()J
-	public abstract fun getVideoEngagementInterval ()Ljava/lang/Double;
 	public static fun init (Ljava/lang/String;ILandroid/content/Context;)V
 	public static fun init (Ljava/lang/String;ILandroid/content/Context;Z)V
 	public static fun init (Ljava/lang/String;Landroid/content/Context;)V
@@ -29,7 +24,6 @@ public abstract interface class com/parsely/parselyandroid/ParselyTracker {
 	public abstract fun trackPageview (Ljava/lang/String;Ljava/lang/String;Lcom/parsely/parselyandroid/ParselyMetadata;Ljava/util/Map;)V
 	public abstract fun trackPause ()V
 	public abstract fun trackPlay (Ljava/lang/String;Ljava/lang/String;Lcom/parsely/parselyandroid/ParselyVideoMetadata;Ljava/util/Map;)V
-	public abstract fun videoIsActive ()Z
 }
 
 public final class com/parsely/parselyandroid/ParselyTracker$Companion {

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -43,13 +43,6 @@ public interface ParselyTracker {
     public val flushInterval: Long
 
     /**
-     * Returns whether the engagement tracker is running.
-     *
-     * @return Whether the engagement tracker is running.
-     */
-    public fun engagementIsActive(): Boolean
-
-    /**
      * Returns whether video tracking is active.
      *
      * @return Whether video tracking is active.

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -132,8 +132,6 @@ public interface ParselyTracker {
      */
     public fun resetVideo()
 
-    public fun flushTimerIsActive(): Boolean
-
     public companion object {
         private const val DEFAULT_FLUSH_INTERVAL_SECS = 60
         private var instance: ParselyTrackerInternal? = null

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -26,12 +26,6 @@ import org.jetbrains.annotations.TestOnly
  */
 public interface ParselyTracker {
 
-    /**
-     * Get the heartbeat interval
-     *
-     * @return The base engagement tracking interval.
-     */
-    public val engagementInterval: Double?
 
     public val videoEngagementInterval: Double?
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -27,13 +27,6 @@ import org.jetbrains.annotations.TestOnly
 public interface ParselyTracker {
 
     /**
-     * Returns whether video tracking is active.
-     *
-     * @return Whether video tracking is active.
-     */
-    public fun videoIsActive(): Boolean
-
-    /**
      * Register a pageview event using a URL and optional metadata.
      *
      * @param url         The URL of the article being tracked

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -27,13 +27,6 @@ import org.jetbrains.annotations.TestOnly
 public interface ParselyTracker {
 
     /**
-     * Returns the interval at which the event queue is flushed to Parse.ly.
-     *
-     * @return The interval at which the event queue is flushed to Parse.ly.
-     */
-    public val flushInterval: Long
-
-    /**
      * Returns whether video tracking is active.
      *
      * @return Whether video tracking is active.

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -26,9 +26,6 @@ import org.jetbrains.annotations.TestOnly
  */
 public interface ParselyTracker {
 
-
-    public val videoEngagementInterval: Double?
-
     /**
      * Returns the interval at which the event queue is flushed to Parse.ly.
      *

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -229,7 +229,7 @@ internal class ParselyTrackerInternal internal constructor(
      *
      * @return Whether the event queue flush timer is running.
      */
-    override fun flushTimerIsActive(): Boolean {
+    private fun flushTimerIsActive(): Boolean {
         return flushManager.isRunning
     }
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -66,7 +66,7 @@ internal class ParselyTrackerInternal internal constructor(
         )
     }
 
-    override val engagementInterval: Double?
+    private val engagementInterval: Double?
         get() = engagementManager?.intervalMillis
 
     override val videoEngagementInterval: Double?

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -72,7 +72,8 @@ internal class ParselyTrackerInternal internal constructor(
     override val videoEngagementInterval: Double?
         get() = videoEngagementManager?.intervalMillis
 
-    override fun engagementIsActive(): Boolean {
+    @Suppress("unused") // used via reflection in sample app
+    private fun engagementIsActive(): Boolean {
         return engagementManager?.isRunning ?: false
     }
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -77,7 +77,7 @@ internal class ParselyTrackerInternal internal constructor(
         return engagementManager?.isRunning ?: false
     }
 
-    override fun videoIsActive(): Boolean {
+    private fun videoIsActive(): Boolean {
         return videoEngagementManager?.isRunning ?: false
     }
 

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -81,7 +81,7 @@ internal class ParselyTrackerInternal internal constructor(
         return videoEngagementManager?.isRunning ?: false
     }
 
-    override val flushInterval: Long
+    private val flushInterval: Long
         get() = flushManager.intervalMillis / 1000
 
     override fun trackPageview(

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -69,7 +69,7 @@ internal class ParselyTrackerInternal internal constructor(
     private val engagementInterval: Double?
         get() = engagementManager?.intervalMillis
 
-    override val videoEngagementInterval: Double?
+    private val videoEngagementInterval: Double?
         get() = videoEngagementManager?.intervalMillis
 
     @Suppress("unused") // used via reflection in sample app

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyTrackerTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyTrackerTest.kt
@@ -11,7 +11,7 @@ class ParselyTrackerTest {
 
     @Test(expected = ParselyNotInitializedException::class)
     fun `given no prior initialization, when executing a method, throw the exception`() {
-        ParselyTracker.sharedInstance().engagementIsActive()
+        ParselyTracker.sharedInstance().startEngagement("url")
     }
 
     @Test(expected = ParselyAlreadyInitializedException::class)
@@ -30,7 +30,7 @@ class ParselyTrackerTest {
     fun `given tracker initialized, when calling a method, do not throw any exception`() {
         ParselyTracker.init(siteId = "", context = RuntimeEnvironment.getApplication())
 
-        ParselyTracker.sharedInstance().engagementIsActive()
+        ParselyTracker.sharedInstance().startEngagement("url")
     }
 
     @After


### PR DESCRIPTION
## Description

This PR removes some methods from the public API. Those methods are not needed to use the SDK and were making the API less readable. Internal communication: p1706537769574079-slack-C0533SEJ82H

### Reflection invocation

Those methods, although not needed for public API, are useful in the scope of the demo app. That's why I've decided to keep them in `ParselyTrackerInternal` and invoke them using reflection.

### Testing

Install the `example` app and tap on each button. The app should not crash.