### PR TITLE
Generate documentation and publish it to GitHub Pages

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,12 +1,21 @@
-name: Generate documentation
+name: Generate and publish documentation
 
 on:
   release:
     types: [ released ]
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
-  build:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -17,8 +26,12 @@ jobs:
           distribution: 'temurin'
       - name: Generate API documentation
         run: ./gradlew dokkaHtml
-      - name: Deploy API documentation to Github Pages
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          branch: gh-pages
-          folder: parsely/build/dokka/html
+          path: 'parsely/build/dokka/html'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,24 @@
+name: Generate documentation
+
+on:
+  release:
+    types: [ released ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Generate API documentation
+        run: ./gradlew dokkaHtml
+      - name: Deploy API documentation to Github Pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: parsely/build/dokka/html


### PR DESCRIPTION
## Description

This PR introduces `Generate and publish documentation` workflow, which generates HTML KDoc artifact and publishes it to GitHub Pages.

In the current form, it will not work as #111 is not merged. I'm merging this workflow, so I can iterate on it in later PRs. Unfortunately, GitHub doesn't allow to run workflow if it's just added to a PR.