### PR TITLE
Bump runtime dependencies

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     namespace = "com.example"
 
     defaultConfig {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -3,13 +3,13 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
     namespace = "com.example"
 
     defaultConfig {
         applicationId "com.parsely.example.parselyexample"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -14,7 +14,7 @@ ext {
 }
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
     namespace = "com.parsely.parselyandroid"
 
     defaultConfig {

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -72,7 +72,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'androidx.lifecycle:lifecycle-process:2.6.2'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -72,7 +72,6 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.4.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
     implementation 'androidx.lifecycle:lifecycle-process:2.6.2'

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -14,12 +14,12 @@ ext {
 }
 
 android {
-    compileSdk 33
+    compileSdk 34
     namespace = "com.parsely.parselyandroid"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'

--- a/parsely/build.gradle
+++ b/parsely/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-process:2.6.2'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
 
-    testImplementation 'org.robolectric:robolectric:4.10.3'
+    testImplementation 'org.robolectric:robolectric:4.11.1'
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation "org.assertj:assertj-core:$assertJVersion"
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
### Description

This PR removes unused `appcompat` dependency and bumps `jackson` library to address publicly known vulnerability ([link](https://mvnrepository.com/artifact/com.parsely/parsely/3.1.1)).