### PR TITLE
Add trackConversion for sending conversion events

### DIFF
--- a/example/src/main/java/com/example/MainActivity.java
+++ b/example/src/main/java/com/example/MainActivity.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.parsely.parselyandroid.ConversionType;
 import com.parsely.parselyandroid.ParselyTracker;
 import com.parsely.parselyandroid.SiteIdSource;
 import com.parsely.parselyandroid.ParselyTrackerInternal;
@@ -138,6 +139,34 @@ public class MainActivity extends Activity {
 
     public void trackReset(View view) {
         ParselyTracker.sharedInstance().resetVideo();
+    }
+
+    // --- Sandbox buttons for trackConversion smoke testing against sandbox.joshhanson.io.
+    // Both fire against the same URL so the conversions topology has a pageview to attribute to.
+    private static final String SANDBOX_SITE_ID = "sandbox.joshhanson.io";
+    private static final String SANDBOX_URL = "https://sandbox.joshhanson.io/path/test-conversion2";
+
+    public void trackSandboxPageview(View view) {
+        final Map<String, Object> extraData = new HashMap<>();
+        extraData.put("source", "android_demo_app");
+        ParselyTracker.sharedInstance().trackPageview(
+                SANDBOX_URL, "", null, extraData, new SiteIdSource.Custom(SANDBOX_SITE_ID)
+        );
+    }
+
+    public void trackSandboxConversion(View view) {
+        final Map<String, Object> extraData = new HashMap<>();
+        extraData.put("plan", "weekly");
+        extraData.put("source", "android_demo_app");
+        ParselyTracker.sharedInstance().trackConversion(
+                SANDBOX_URL,
+                ConversionType.SUBSCRIPTION,
+                "android_sdk_smoke_test",
+                "",
+                null,
+                extraData,
+                new SiteIdSource.Custom(SANDBOX_SITE_ID)
+        );
     }
 
     private SiteIdSource getSiteId() {

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -76,11 +76,29 @@
         android:onClick="trackReset"
         android:text="@string/button_reset_video" />
 
+    <Button
+        android:id="@+id/sandbox_pageview_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/reset_video_button"
+        android:layout_centerHorizontal="true"
+        android:onClick="trackSandboxPageview"
+        android:text="@string/button_sandbox_pageview" />
+
+    <Button
+        android:id="@+id/sandbox_conversion_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/sandbox_pageview_button"
+        android:layout_centerHorizontal="true"
+        android:onClick="trackSandboxConversion"
+        android:text="@string/button_sandbox_conversion" />
+
     <TextView android:id="@+id/interval"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
-        android:layout_below="@id/reset_video_button"
+        android:layout_below="@id/sandbox_conversion_button"
         android:text="Flush timer inactive"/>
 
     <TextView

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -8,5 +8,7 @@
     <string name="button_track_video">Track Video</string>
     <string name="button_pause_video">Pause Video</string>
     <string name="button_reset_video">Reset Video</string>
+    <string name="button_sandbox_pageview">Track Pageview (sandbox)</string>
+    <string name="button_sandbox_conversion">Track Conversion (sandbox)</string>
 
 </resources>

--- a/parsely/src/main/java/com/parsely/parselyandroid/ConversionType.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ConversionType.kt
@@ -1,0 +1,15 @@
+package com.parsely.parselyandroid
+
+/**
+ * The category of a conversion event. The [wireValue] of each case is the string sent to
+ * Parse.ly over the wire and must match the values accepted by the Parse.ly conversions
+ * backend. Use [CUSTOM] for conversions that don't fit one of the named categories.
+ */
+public enum class ConversionType(internal val wireValue: String) {
+    NEWSLETTER_SIGNUP("newsletter_signup"),
+    LEAD_CAPTURE("lead_capture"),
+    LINK_CLICK("link_click"),
+    SUBSCRIPTION("subscription"),
+    PURCHASE("purchase"),
+    CUSTOM("custom"),
+}

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTracker.kt
@@ -135,6 +135,35 @@ public interface ParselyTracker {
      */
     public fun resetVideo()
 
+    /**
+     * Track a conversion event (e.g. newsletter signup, subscription, purchase).
+     *
+     * The category and label are merged into the event's `extra_data` under the reserved keys
+     * `_conversion_type` and `_conversion_label`, which the Parse.ly conversions backend uses to
+     * identify the goal. Reserved keys cannot be overridden via [extraData].
+     *
+     * @param url             The URL at which the conversion occurred.
+     * @param conversionType  The category of conversion. Use [ConversionType.CUSTOM] for
+     *                        conversions that don't fit the named categories.
+     * @param conversionLabel A customer-defined identifier for this conversion (e.g.
+     *                        "weekly_plan", "homepage_cta"). Events without a label are dropped
+     *                        by the Parse.ly conversions backend.
+     * @param urlRef          The url of the page that linked to the conversion page. Analogous to HTTP referer.
+     * @param urlMetadata     Optional metadata for the URL.
+     * @param extraData       A map of additional information to send with the event. Reserved keys
+     *                        `_conversion_type` and `_conversion_label` will be overwritten.
+     * @param siteIdSource    The source of the site ID to use for the event.
+     */
+    public fun trackConversion(
+        url: String,
+        conversionType: ConversionType,
+        conversionLabel: String,
+        urlRef: String = "",
+        urlMetadata: ParselyMetadata? = null,
+        extraData: Map<String, Any>? = null,
+        siteIdSource: SiteIdSource = SiteIdSource.Default,
+    )
+
     public companion object {
         private const val DEFAULT_FLUSH_INTERVAL_SECS = 60
         private var instance: ParselyTrackerInternal? = null

--- a/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
+++ b/parsely/src/main/java/com/parsely/parselyandroid/ParselyTrackerInternal.kt
@@ -206,6 +206,38 @@ internal class ParselyTrackerInternal internal constructor(
         videoEngagementManager = null
     }
 
+    override fun trackConversion(
+        url: String,
+        conversionType: ConversionType,
+        conversionLabel: String,
+        urlRef: String,
+        urlMetadata: ParselyMetadata?,
+        extraData: Map<String, Any>?,
+        siteIdSource: SiteIdSource,
+    ) {
+        if (url.isBlank()) {
+            Log.e("url cannot be empty")
+            return
+        }
+
+        val mergedExtraData = (extraData ?: emptyMap()) + mapOf(
+            "_conversion_type" to conversionType.wireValue,
+            "_conversion_label" to conversionLabel,
+        )
+
+        enqueueEvent(
+            eventsBuilder.buildEvent(
+                url,
+                urlRef,
+                "conversion",
+                urlMetadata,
+                mergedExtraData,
+                generatePixelId(),
+                siteIdSource
+            )
+        )
+    }
+
     /**
      * Add an event Map to the queue.
      * Place a data structure representing the event into the in-memory queue for later use.

--- a/parsely/src/test/java/com/parsely/parselyandroid/EventsBuilderTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/EventsBuilderTest.kt
@@ -208,6 +208,43 @@ internal class EventsBuilderTest {
 
 
     @Test
+    fun `when building conversion event, then build the correct one`() {
+        // given
+        val extraData: Map<String, Any> = mapOf(
+            "_conversion_type" to "subscription",
+            "_conversion_label" to "weekly_plan",
+            "plan" to "Active",
+        )
+
+        // when
+        val event: Map<String, Any> = sut.buildEvent(
+            TEST_URL,
+            "",
+            "conversion",
+            null,
+            extraData,
+            TEST_UUID,
+            SiteIdSource.Default,
+        )
+
+        // then
+        assertThat(event)
+            .doesNotContainKey("pvid")
+            .doesNotContainKey("vsid")
+            .containsEntry("action", "conversion")
+            .containsEntry("url", TEST_URL)
+            .containsEntry("idsite", TEST_SITE_ID)
+            .hasEntrySatisfying("data") {
+                @Suppress("UNCHECKED_CAST")
+                it as Map<String, Any>
+                assertThat(it)
+                    .containsEntry("_conversion_type", "subscription")
+                    .containsEntry("_conversion_label", "weekly_plan")
+                    .containsEntry("plan", "Active")
+            }
+    }
+
+    @Test
     fun `given custom site id is provided, when creating a pixel, then use the custom site id`() {
         // given
         val customSiteId = "Custom Site ID"

--- a/parsely/src/test/java/com/parsely/parselyandroid/ParselyTrackerTest.kt
+++ b/parsely/src/test/java/com/parsely/parselyandroid/ParselyTrackerTest.kt
@@ -33,6 +33,17 @@ class ParselyTrackerTest {
         ParselyTracker.sharedInstance().startEngagement("url")
     }
 
+    @Test
+    fun `given tracker initialized, when calling trackConversion, do not throw any exception`() {
+        ParselyTracker.init(siteId = "example.com", context = RuntimeEnvironment.getApplication())
+
+        ParselyTracker.sharedInstance().trackConversion(
+            url = "https://example.com/path/test-conversion",
+            conversionType = ConversionType.SUBSCRIPTION,
+            conversionLabel = "weekly_plan",
+        )
+    }
+
     @After
     fun tearDown() {
         ParselyTracker.tearDown()


### PR DESCRIPTION
## Summary
- Adds `ParselyTracker.trackConversion(url, conversionType, conversionLabel, ...)` for firing conversion events (newsletter signups, subscriptions, purchases, link clicks, lead capture, custom). Internally constructs an event with `action="conversion"` and merges `_conversion_type` and `_conversion_label` into `extra_data`, which the Parse.ly conversions backend (`conversions-realtime`) extracts and uses as the goal identity.
- New `ConversionType` enum mirrors the categories accepted server-side (`newsletter_signup`, `lead_capture`, `link_click`, `subscription`, `purchase`, `custom`).
- Reuses the existing `EventsBuilder` / `InMemoryBuffer` / `FlushQueue` / `ParselyAPIConnection` pipeline — zero changes to the network layer, the buffer, or the flush manager.
- Example app gains two sandbox buttons used during end-to-end verification.

This is the Android counterpart to the iOS SDK's `trackConversion` (parallel PR on AnalyticsSDK-iOS).

## Test plan

### Unit tests (all passing)
- [x] `EventsBuilderTest.when building conversion event, then build the correct one` — verifies the built event has `action == "conversion"`, the right `url` and `idsite`, no `pvid` / `vsid`, and that `_conversion_type` / `_conversion_label` plus caller-supplied keys land in `data`.
- [x] `ParselyTrackerTest.given tracker initialized, when calling trackConversion, do not throw any exception` — smoke test for the public entry point (mirrors the existing call-doesn't-throw tests for other tracking methods).

Full suite (`./gradlew :parsely:testDebugUnitTest`): EventsBuilderTest 11 tests / ParselyTrackerTest 5 tests / 0 failures.

### Manual end-to-end (Android emulator: Pixel 5, android-34, default arm64-v8a)
- [x] Built and installed the example app on the emulator.
- [x] Flipped `dryRun` to `false` temporarily in `MainActivity.java` to exercise the real network path.
- [x] Tapped **Track Pageview (sandbox)** and **Track Conversion (sandbox)** against the `sandbox.joshhanson.io` apikey.
- [x] Verified the on-wire JSON via `adb logcat Parsely:V '*:S'`:
  ```json
  {
    "action": "conversion",
    "url": "https://sandbox.joshhanson.io/path/test-conversion2",
    "idsite": "sandbox.joshhanson.io",
    "data": {
      "_conversion_type": "subscription",
      "_conversion_label": "android_sdk_smoke_test",
      "plan": "weekly",
      "source": "android_demo_app",
      "os": "android",
      "os_version": "34",
      "parsely_site_uuid": "...",
      "ts": 1778782087996
    }
  }
### Testing Screenshots
<img width="782" height="1744" alt="Xnip2026-05-14_20-27-24" src="https://github.com/user-attachments/assets/65e59701-fbb1-44f5-8a46-79dfb6945151" />

<img width="973" height="434" alt="Screenshot 2026-05-14 at 8 46 39 PM" src="https://github.com/user-attachments/assets/2cddaae4-3065-4b36-8d05-cb559b59f347" />


